### PR TITLE
audio crash fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,6 @@ version = "3.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "cpal",
  "curl",
  "flate2",
  "getopts",
@@ -1994,8 +1993,7 @@ dependencies = [
 [[package]]
 name = "rodio"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9683532495146e98878d4948fa1a1953f584cd923f2a5f5c26b7a8701b56943"
+source = "git+https://github.com/LiquidityC/rodio#b4d812069bf81311e299ef0a81feb81022a96654"
 dependencies = [
  "claxon",
  "cpal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ version = "3.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "cpal",
  "curl",
  "flate2",
  "getopts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [features]
 text-to-speech = ["tts"]
+audio = []
 
 [dependencies]
 libtelnet-rs = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tts = { version = "0.13.1", optional = true }
 serde_json = "1.0.61"
 git2 = "0.13.15"
 rodio = "0.13.0"
+cpal = "0.13.1"
 
 [dev-dependencies]
 mockall = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,7 @@ native-tls = "0.2.7"
 tts = { version = "0.13.1", optional = true }
 serde_json = "1.0.61"
 git2 = "0.13.15"
-rodio = "0.13.0"
-cpal = "0.13.1"
+rodio = { git = "https://github.com/LiquidityC/rodio" }
 
 [dev-dependencies]
 mockall = "0.9.0"

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -1,6 +1,7 @@
 use std::{fs::File, io::BufReader};
 
 use anyhow::Result;
+use cpal::traits::HostTrait;
 use rodio::{Sink, Source};
 
 pub struct Player {
@@ -16,11 +17,15 @@ impl Player {
         let mut sfx = None;
         let mut stream = None;
         let mut handle = None;
-        if let Ok((ostream, ohandle)) = rodio::OutputStream::try_default() {
-            music = rodio::Sink::try_new(&ohandle).ok();
-            sfx = rodio::Sink::try_new(&ohandle).ok();
-            stream = Some(ostream);
-            handle = Some(ohandle);
+
+        let host = cpal::default_host();
+        if host.default_output_device().is_some() {
+            if let Ok((ostream, ohandle)) = rodio::OutputStream::try_default() {
+                music = rodio::Sink::try_new(&ohandle).ok();
+                sfx = rodio::Sink::try_new(&ohandle).ok();
+                stream = Some(ostream);
+                handle = Some(ohandle);
+            }
         }
 
         Self {

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -1,6 +1,7 @@
 use std::{fs::File, io::BufReader};
 
 use anyhow::Result;
+
 use rodio::cpal::traits::HostTrait;
 use rodio::{Sink, Source};
 
@@ -18,13 +19,15 @@ impl Player {
         let mut stream = None;
         let mut handle = None;
 
-        let host = rodio::cpal::default_host();
-        if host.default_output_device().is_some() {
-            if let Ok((ostream, ohandle)) = rodio::OutputStream::try_default() {
-                music = rodio::Sink::try_new(&ohandle).ok();
-                sfx = rodio::Sink::try_new(&ohandle).ok();
-                stream = Some(ostream);
-                handle = Some(ohandle);
+        if cfg!(audio) {
+            let host = rodio::cpal::default_host();
+            if host.default_output_device().is_some() {
+                if let Ok((ostream, ohandle)) = rodio::OutputStream::try_default() {
+                    music = rodio::Sink::try_new(&ohandle).ok();
+                    sfx = rodio::Sink::try_new(&ohandle).ok();
+                    stream = Some(ostream);
+                    handle = Some(ohandle);
+                }
             }
         }
 

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::BufReader};
 
 use anyhow::Result;
-use cpal::traits::HostTrait;
+use rodio::cpal::traits::HostTrait;
 use rodio::{Sink, Source};
 
 pub struct Player {
@@ -18,7 +18,7 @@ impl Player {
         let mut stream = None;
         let mut handle = None;
 
-        let host = cpal::default_host();
+        let host = rodio::cpal::default_host();
         if host.default_output_device().is_some() {
             if let Ok((ostream, ohandle)) = rodio::OutputStream::try_default() {
                 music = rodio::Sink::try_new(&ohandle).ok();


### PR DESCRIPTION
- Attempts to prevent bad error handling in rodio from crashing blightmud
- Changes rodio dep to patched version re-exporting cpal
- Hides audio init behind feature

Since rodio seems slightly unstable I'm placing the audio feature behind an opt-in feature
for the time being. We'll have to decide how to continue.
