### PR TITLE
Clean up global scope

### DIFF
--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -58,12 +58,12 @@ impl UserData for Blight {
             Ok(this.screen_dimensions)
         });
         methods.add_function("bind", |ctx, (cmd, callback): (String, mlua::Function)| {
-            let bind_table: mlua::Table = ctx.globals().get(COMMAND_BINDING_TABLE)?;
+            let bind_table: mlua::Table = ctx.named_registry_value(COMMAND_BINDING_TABLE)?;
             bind_table.set(cmd.to_lowercase(), callback)?;
             Ok(())
         });
         methods.add_function("unbind", |ctx, cmd: String| {
-            let bind_table: mlua::Table = ctx.globals().get(COMMAND_BINDING_TABLE)?;
+            let bind_table: mlua::Table = ctx.named_registry_value(COMMAND_BINDING_TABLE)?;
             bind_table.set(cmd, mlua::Nil)?;
             Ok(())
         });

--- a/src/lua/core.rs
+++ b/src/lua/core.rs
@@ -45,21 +45,19 @@ impl UserData for Core {
             Ok(())
         });
         methods.add_function_mut("on_protocol_enabled", |ctx, cb: mlua::Function| {
-            let globals = ctx.globals();
-            let table: Table = globals.get(PROTO_ENABLED_LISTENERS_TABLE)?;
+            let table: Table = ctx.named_registry_value(PROTO_ENABLED_LISTENERS_TABLE)?;
             let this_aux = ctx.globals().get::<_, AnyUserData>("core")?;
             let mut this = this_aux.borrow_mut::<Core>()?;
             table.set(this.next_index(), cb)?;
-            globals.set(PROTO_ENABLED_LISTENERS_TABLE, table)?;
+            ctx.set_named_registry_value(PROTO_ENABLED_LISTENERS_TABLE, table)?;
             Ok(())
         });
         methods.add_function_mut("subneg_recv", |ctx, cb: mlua::Function| {
-            let globals = ctx.globals();
-            let table: Table = globals.get(PROTO_SUBNEG_LISTENERS_TABLE)?;
+            let table: Table = ctx.named_registry_value(PROTO_SUBNEG_LISTENERS_TABLE)?;
             let this_aux = ctx.globals().get::<_, AnyUserData>("core")?;
             let mut this = this_aux.borrow_mut::<Core>()?;
             table.set(this.next_index(), cb)?;
-            globals.set(PROTO_SUBNEG_LISTENERS_TABLE, table)?;
+            ctx.set_named_registry_value(PROTO_SUBNEG_LISTENERS_TABLE, table)?;
             Ok(())
         });
         methods.add_function_mut("subneg_send", |ctx, (proto, bytes): (u8, Table)| {

--- a/src/lua/mud.rs
+++ b/src/lua/mud.rs
@@ -94,14 +94,12 @@ impl UserData for Mud {
             Ok(())
         });
         methods.add_function("on_connect", |ctx, callback: mlua::Function| {
-            let globals = ctx.globals();
-            let table: mlua::Table = globals.get(ON_CONNECTION_CALLBACK_TABLE)?;
+            let table: mlua::Table = ctx.named_registry_value(ON_CONNECTION_CALLBACK_TABLE)?;
             table.raw_set(table.raw_len() + 1, callback)?;
             Ok(())
         });
         methods.add_function("on_disconnect", |ctx, callback: mlua::Function| {
-            let globals = ctx.globals();
-            let table: mlua::Table = globals.get(ON_DISCONNECT_CALLBACK_TABLE)?;
+            let table: mlua::Table = ctx.named_registry_value(ON_DISCONNECT_CALLBACK_TABLE)?;
             table.set(table.raw_len() + 1, callback)?;
             Ok(())
         });


### PR DESCRIPTION
Removes the following variables from the global scope:
- `__connection_callback_table`
- `__disconnect_callback_table`
- `__protocol_subneg_listeners`
- `__cmd_binds`
- `__protocol_enabled_listeners`
- `prettywrite`
- `display`
- `lua_keywords`

All the variables starting with `__` just needed to use named registry values instead of a global.
`prettywrite` and `display` were functions in `lua_command.lua` that really should be local. As a side-effect of making them local, there had to be some rearranging, as you can only reference local function previously defined. Unfortunately, `quote` and `prettywrite` are mutually recursive, so `prettywrite` had to be forward-declared.

`lua_keyword` was a global that `lua_command.lua` creates to cache some data. Can easily be local.