### PR TITLE
Allows multiple receivers for gmcp data

### DIFF
--- a/src/net/check_version.rs
+++ b/src/net/check_version.rs
@@ -103,7 +103,10 @@ mod test_version_diff {
         run(writer, "v1.0.0", &fetcher);
         assert_eq!(
             reader.try_recv().unwrap(),
-            Event::Info("There is a newer version of Blightmud available. (current: v1.0.0, new: v10.0.0)".to_string())
+            Event::Info(
+                "There is a newer version of Blightmud available. (current: v1.0.0, new: v10.0.0)"
+                    .to_string()
+            )
         );
         assert_eq!(
             reader.try_recv().unwrap(),
@@ -116,9 +119,10 @@ mod test_version_diff {
         let mut fetcher = MockFetchVersionInformation::new();
         let (writer, reader): (Sender<Event>, Receiver<Event>) = channel();
 
-        fetcher.expect_fetch().times(1).returning(|| {
-            Ok(br#"{"tag_name":"v1.0.0","html_url":"http://example.com"}"#.to_vec())
-        });
+        fetcher
+            .expect_fetch()
+            .times(1)
+            .returning(|| Ok(br#"{"tag_name":"v1.0.0","html_url":"http://example.com"}"#.to_vec()));
 
         run(writer, "v1.0.0", &fetcher);
         assert!(reader.try_recv().is_err());

--- a/src/ui/screen.rs
+++ b/src/ui/screen.rs
@@ -875,21 +875,14 @@ mod screen_test {
         for _ in 0..1000 {
             for i in 0..10 {
                 let num = format!("{}", i);
-                line = format!(
-                    "{}{}",
-                    line,
-                    num.repeat(15)
-                );
+                line = format!("{}{}", line, num.repeat(15));
             }
         }
         let lines = wrap_line(&line, 15);
         assert_eq!(lines.len(), 1000 * 10);
         for (i, line) in lines.iter().enumerate() {
             let num = format!("{}", i % 10);
-            assert_eq!(
-                line,
-                &num.repeat(15).to_string()
-            );
+            assert_eq!(line, &num.repeat(15).to_string());
         }
     }
 


### PR DESCRIPTION
Also introduces a data cache for gmcp data so that receivers can recieve
data as soon as they register if anything has already been sent.
