### PR TITLE
Conversion to libtelnet-rs 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.ron
 /tags
 /.run/
+/.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,9 +1072,12 @@ dependencies = [
 
 [[package]]
 name = "libtelnet-rs"
-version = "1.1.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992ba607a47645788936f482802517100cb9e0f5f1c4ddd3c3a16d1edce77258"
+checksum = "8b91f14f906b14bbd9c2a4c6a81d6f01b825438de64adb3b15c8fcc223de25a1"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "libz-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 text-to-speech = ["tts"]
 
 [dependencies]
-libtelnet-rs = "1.1.2"
+libtelnet-rs = "2.0.0"
 termion = "1.5.6"
 log = "0.4.14"
 simple-logging = "2.0.2"

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,7 +8,7 @@ use crate::{
     ui::UserInterface,
     TelnetData,
 };
-use libtelnet_rs::events::TelnetEvents;
+use libtelnet_rs::{bytes::Bytes, events::TelnetEvents};
 use log::debug;
 use std::{
     error::Error,
@@ -45,8 +45,8 @@ pub enum Event {
     PlaySFX(String, SourceOptions),
     Prompt(Line),
     ProtoEnabled(u8),
-    ProtoSubnegRecv(u8, Vec<u8>),
-    ProtoSubnegSend(u8, Vec<u8>),
+    ProtoSubnegRecv(u8, Bytes),
+    ProtoSubnegSend(u8, Bytes),
     Quit(QuitMethod),
     Reconnect,
     Redraw,
@@ -58,7 +58,7 @@ pub enum Event {
     ScrollTop,
     ScrollUp,
     ServerInput(Line),
-    ServerSend(Vec<u8>),
+    ServerSend(Bytes),
     SettingChanged(String, bool),
     ShowHelp(String, bool),
     Speak(String, bool),

--- a/src/lua/core.rs
+++ b/src/lua/core.rs
@@ -1,5 +1,6 @@
 use std::sync::mpsc::Sender;
 
+use libtelnet_rs::bytes::Bytes;
 use log::debug;
 use mlua::{AnyUserData, Table, UserData, UserDataMethods};
 
@@ -67,7 +68,7 @@ impl UserData for Core {
                 .pairs::<i32, u8>()
                 .filter_map(Result::ok)
                 .map(|pair| pair.1)
-                .collect::<Vec<u8>>();
+                .collect::<Bytes>();
             debug!("lua subneg: {}", String::from_utf8_lossy(&data).to_mut());
             this.main_writer
                 .send(Event::ProtoSubnegSend(proto, data))

--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -417,6 +417,7 @@ mod lua_script_tests {
     use crate::lua::constants::TIMED_CALLBACK_TABLE;
     use crate::model::{Connection, Regex};
     use crate::{event::Event, lua::regex::Regex as LReg, model::Line, PROJECT_NAME, VERSION};
+    use libtelnet_rs::{bytes::Bytes, vbytes};
     use std::{
         collections::BTreeMap,
         sync::mpsc::{channel, Receiver, Sender},
@@ -634,7 +635,10 @@ mod lua_script_tests {
 
         assert_eq!(
             reader.recv(),
-            Ok(Event::ProtoSubnegSend(201, vec![255, 250, 86, 255, 240]))
+            Ok(Event::ProtoSubnegSend(
+                201,
+                vbytes!(&[255, 250, 86, 255, 240])
+            ))
         );
     }
 

--- a/src/lua/mud.rs
+++ b/src/lua/mud.rs
@@ -1,3 +1,4 @@
+use libtelnet_rs::bytes::Bytes;
 use mlua::{Function, Table, UserData, UserDataMethods};
 
 use crate::{
@@ -93,7 +94,10 @@ impl UserData for Mud {
         );
         methods.add_function("send_bytes", |ctx, bytes: Vec<u8>| {
             let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend.writer.send(Event::ServerSend(bytes)).unwrap();
+            backend
+                .writer
+                .send(Event::ServerSend(Bytes::from(bytes)))
+                .unwrap();
             Ok(())
         });
         methods.add_function("input", |ctx, line: String| {
@@ -124,6 +128,7 @@ impl UserData for Mud {
 mod test_mud {
     use std::sync::mpsc::{channel, Receiver, Sender};
 
+    use libtelnet_rs::{bytes::Bytes, vbytes};
     use mlua::Lua;
 
     use crate::{
@@ -248,7 +253,7 @@ mod test_mud {
     fn test_send_bytes() {
         assert_event(
             "mud.send_bytes({ 0xff, 0xf1 })",
-            Event::ServerSend(vec![0xff, 0xf1]),
+            Event::ServerSend(vbytes!(&[0xff, 0xf1])),
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use audio::Player;
 use lazy_static::lazy_static;
+use libtelnet_rs::bytes::Bytes;
 use libtelnet_rs::events::TelnetEvents;
 use log::{error, info};
 use std::path::PathBuf;
@@ -42,7 +43,7 @@ const XDG_DATA_DIR: &str = "~/.local/share/blightmud";
 #[cfg(not(debug_assertions))]
 const XDG_CONFIG_DIR: &str = "~/.config/blightmud";
 
-type TelnetData = Option<Vec<u8>>;
+type TelnetData = Option<Bytes>;
 
 lazy_static! {
     pub static ref DATA_DIR: PathBuf = {

--- a/src/net/telnet.rs
+++ b/src/net/telnet.rs
@@ -99,7 +99,7 @@ impl TelnetHandler {
                 }
                 TelnetEvents::DecompressImmediate(buffer) => {
                     debug!("Breaking on buff: {:?}", &buffer);
-                    result = Some(buffer);
+                    result = Some(buffer.to_vec());
                     break;
                 }
                 TelnetEvents::Subnegotiation(data) => match data.option {
@@ -111,7 +111,7 @@ impl TelnetHandler {
                     }
                     opt => {
                         self.main_writer
-                            .send(Event::ProtoSubnegRecv(opt, data.buffer.to_vec()))
+                            .send(Event::ProtoSubnegRecv(opt, data.buffer))
                             .unwrap();
                     }
                 },
@@ -123,7 +123,7 @@ impl TelnetHandler {
                 }
                 TelnetEvents::DataReceive(msg) => {
                     debug!("Data receive: {:?}", msg);
-                    if !msg.is_empty() && msg != [0] {
+                    if !msg.is_empty() && msg[0] != 0 {
                         if let Ok(mut output_buffer) = self.output_buffer.lock() {
                             let new_lines = output_buffer.receive(&msg);
                             for line in new_lines {


### PR DESCRIPTION
This updates many (if not most) areas in the code that previously were broken with the change to libtelnet-rs v2.0.0

This provides compatibility with the breaking change to using the `bytes` crate, including tests and lua calls.