### PR TITLE
help: fix stale lua_gmcp.md send_gmcp reference.

### DIFF
--- a/resources/help/lua_gmcp.md
+++ b/resources/help/lua_gmcp.md
@@ -50,7 +50,7 @@ Sends the provided msg string as GMCP to the MUD.
 
 ```lua
 data = { char = { hp = "1234" } }
-gmcp.send_gmcp("Char.Health " .. json.encode(data))
+gmcp.send("Char.Health " .. json.encode(data))
 ```
 
 ##


### PR DESCRIPTION
Since d938f144ac32936027165170d86de6f6a28420a6 the `gmcp.send_gmcp` method has been replaced by `gmcp.send`. One stale reference to `send_gmcp` persisted in example documentation and is fixed in this commit.