### PR TITLE
regex:new now support some options

### DIFF
--- a/resources/help/regex.md
+++ b/resources/help/regex.md
@@ -5,8 +5,15 @@ be created and used to match and replace content in strings.
 
 ##
 
-***regex.new(pattern)***
+***regex.new(pattern, options)***
 Creates a new regular expression.
+
+- `pattern` Regex-pattern
+- `options` An optional table of options (see `Options` below)
+
+**Options**
+- `case_insensitive` Regex-flag (i): case insensitive match
+- `multi_line`       Regex-flag (m): ^ and $ match start/end of line
 
 ##
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -428,17 +428,17 @@ mod event_test {
     #[test]
     fn test_find() {
         let (session, _reader, _timer_reader) = build_session();
-        let re = Regex::new("test").unwrap();
+        let re = Regex::new("test", None).unwrap();
         let mut screen = MockUserInterface::new();
         screen
             .expect_find_down()
             .times(1)
-            .withf(|other| *other == Regex::new("test").unwrap())
+            .withf(|other| *other == Regex::new("test", None).unwrap())
             .returning(|_| Ok(()));
         screen
             .expect_find_up()
             .times(1)
-            .withf(|other| *other == Regex::new("test").unwrap())
+            .withf(|other| *other == Regex::new("test", None).unwrap())
             .returning(|_| Ok(()));
         let handler = EventHandler::from(&session);
         let mut screen: Box<dyn UserInterface> = Box::new(screen);

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -278,7 +278,7 @@ mod test_blight {
     #[test]
     fn find() {
         let (lua, reader) = get_lua_state();
-        let re = crate::model::Regex::new("test").unwrap();
+        let re = crate::model::Regex::new("test", None).unwrap();
         lua.load(r#"blight.find_forward(regex.new("test"))"#)
             .exec()
             .unwrap();

--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -1099,7 +1099,7 @@ mod lua_script_tests {
     fn confirm_search_macros() {
         let (lua, reader) = get_lua();
         lua.on_mud_input(&mut Line::from("/search test1"));
-        let re = Regex::new("test1").unwrap();
+        let re = Regex::new("test1", None).unwrap();
         assert_eq!(reader.recv().unwrap(), Event::FindBackward(re.clone()));
         lua.on_mud_input(&mut Line::from("/s test1"));
         assert_eq!(reader.recv().unwrap(), Event::FindBackward(re));

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,7 +3,7 @@ mod connection;
 mod line;
 mod regex;
 mod settings;
-pub use self::regex::Regex;
+pub use self::{regex::Regex, regex::RegexOptions};
 pub use completions::Completions;
 pub use connection::{Connection, Servers};
 pub use line::Line;

--- a/src/model/regex.rs
+++ b/src/model/regex.rs
@@ -1,8 +1,23 @@
 use core::ops::Deref;
-use regex::Regex as MRegex;
+use regex::{Regex as MRegex, RegexBuilder};
 use std::ops::DerefMut;
 
 use anyhow::Result;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RegexOptions {
+    pub case_insensitive: bool,
+    pub multi_line: bool,
+}
+
+impl Default for RegexOptions {
+    fn default() -> Self {
+        Self {
+            case_insensitive: false,
+            multi_line: false,
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct Regex {
@@ -10,9 +25,14 @@ pub struct Regex {
 }
 
 impl Regex {
-    pub fn new(pattern: &str) -> Result<Self> {
+    pub fn new(pattern: &str, options: Option<RegexOptions>) -> Result<Self> {
+        let mut regex_builder = RegexBuilder::new(pattern);
+        if let Some(options) = options {
+            regex_builder.case_insensitive(options.case_insensitive);
+            regex_builder.multi_line(options.multi_line);
+        }
         Ok(Self {
-            inner: MRegex::new(pattern)?,
+            inner: regex_builder.build()?,
         })
     }
 }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -122,7 +122,7 @@ mod test {
         }
         let mut index = history.len();
         let mut goal = 11000;
-        let pattern = Regex::new("^something$").unwrap();
+        let pattern = Regex::new("^something$", None).unwrap();
         while index > 0 && goal > 0 {
             index = if let Some(i) = history.find_backward(&pattern, index) {
                 i

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -690,7 +690,7 @@ mod screen_test {
 
         let mut history = History::new();
         history.append(line);
-        let re = crate::model::Regex::new("and lines").unwrap();
+        let re = crate::model::Regex::new("and lines", None).unwrap();
         assert_eq!(history.find_forward(&re, 0), Some(3));
         assert_eq!(history.find_forward(&re, 4), None);
         assert_eq!(history.find_backward(&re, 4), Some(3));


### PR DESCRIPTION
- switched from Regex to RegexBuilder to support some regex options
- added support for multi_line and case_insensitive RegexBuilder options
- added some tests
- added documentation

This is my first public Rust contribution so please let me know if something is wired. I tried hard to adopt the coding style. If the code is fine this way, i might add this flags as well (dot_matches_new_line, swap_greed, ignore_whitespace). 

Fixes #536