### PR TITLE
Support capitalized key value in bindings

### DIFF
--- a/resources/help/bindings.md
+++ b/resources/help/bindings.md
@@ -5,7 +5,9 @@ pressed. This also include re-binding keys to a setup you are more comfortable
 with rather then the default.
 
 - `Ctrl-<char>` ex. `Ctrl-a, Ctrl-b` but not `Ctrl-PgUp`, there is no distinction for capitalization
-- `Alt-<char>` ex. `Alt-a, Alt-b` but not `Alt-PgUp`, there is no distinction for capitalization
+- `Alt-<char>` ex. `Alt-a, Alt-b` but not `Alt-PgUp`, there is distinction for capitalization.
+  For example `Alt-H`, which is basically `Alt-Shift-h`, and `Alt-h` are treated
+  as different bindings.
 - `F1-F12`
 
 You may also bind on escape sequences. For example `\x1b[1;5A` (ctrl-up). When
@@ -17,7 +19,7 @@ Is the command to use when creating a binding.
 
 `cmd` has to be in the following format:
 - `Ctrl-{}` where {} is a character, ex. a, b, c, etc.
-- `Alt-{}` where {} is a character, ex. a, b, c, etc.
+- `Alt-{}` where {} is a character, ex. a, b, c, A, B, C, etc.
 - `fn` where n is a number from 1-12
 - Or an escape sequence such as `\x1b[1;5A`
 

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -59,7 +59,14 @@ impl UserData for Blight {
         });
         methods.add_function("bind", |ctx, (cmd, callback): (String, mlua::Function)| {
             let bind_table: mlua::Table = ctx.named_registry_value(COMMAND_BINDING_TABLE)?;
-            bind_table.set(cmd.to_lowercase(), callback)?;
+            if let Some(n) = cmd.find('-') {
+                let (cmd, right) = cmd.split_at(n);
+                let mut cmd = cmd.to_lowercase();
+                cmd.push_str(right);
+                bind_table.set(cmd, callback)?;
+            } else {
+                bind_table.set(cmd.to_lowercase(), callback)?;
+            }
             Ok(())
         });
         methods.add_function("unbind", |ctx, cmd: String| {
@@ -348,5 +355,16 @@ mod test_blight {
         assert!(bindings.get::<_, mlua::Function>("f1").is_ok());
         lua.load("blight.unbind(\"f1\")").exec().unwrap();
         assert!(bindings.get::<_, mlua::Function>("f1").is_err());
+    }
+
+    #[test]
+    fn test_command_bindings_with_capitalized_letter() {
+        let (lua, _) = get_lua_state();
+        lua.load("blight.bind(\"Alt-H\", function () end)")
+            .exec()
+            .unwrap();
+        let bindings: mlua::Table = lua.named_registry_value(COMMAND_BINDING_TABLE).unwrap();
+        assert!(bindings.get::<_, mlua::Function>("alt-H").is_ok());
+        assert!(bindings.get::<_, mlua::Function>("alt-h").is_err());
     }
 }

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -59,9 +59,9 @@ impl UserData for Blight {
         });
         methods.add_function("bind", |ctx, (cmd, callback): (String, mlua::Function)| {
             let bind_table: mlua::Table = ctx.named_registry_value(COMMAND_BINDING_TABLE)?;
-            if let Some(n) = cmd.find('-') {
-                let (cmd, right) = cmd.split_at(n);
-                let mut cmd = cmd.to_lowercase();
+            if cmd.to_lowercase().starts_with("alt-") {
+                let (_, right) = cmd.split_at(3);
+                let mut cmd = "alt".to_string();
                 cmd.push_str(right);
                 bind_table.set(cmd, callback)?;
             } else {
@@ -358,7 +358,7 @@ mod test_blight {
     }
 
     #[test]
-    fn test_command_bindings_with_capitalized_letter() {
+    fn test_command_bindings_alt_with_capitalized_letter() {
         let (lua, _) = get_lua_state();
         lua.load("blight.bind(\"Alt-H\", function () end)")
             .exec()


### PR DESCRIPTION
While migrating my bindings from TF to Blight, I noticed there is not way to bind `alt-shift-h` for example. Because `alt-H` would be normalized to `alt-h` during binding.

With this change, it's possible to bind keys like `alt-H`, which is basically `alt-shift-h`.

However I am not sure how would one bind `ctrl-alt-h` for example. I checked `Termion` and it seems not supported?