### PR TITLE
Update coverage worker with new flag

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run tests
         run: cargo test
         env:
-          RUSTFLAGS: '-Zinstrument-coverage'
+          RUSTFLAGS: '-C instrument-coverage'
           LLVM_PROFILE_FILE: 'report-%p-%m.profraw'
       - name: Run grcov
         run: grcov . --binary-path target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage.lcov


### PR DESCRIPTION
'-Zinstrument-coverage' is deprecated in favor of '-C instrument-coverage'
