### PR TITLE
Consider erroring input listeners to have matched

### DIFF
--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -249,7 +249,7 @@ impl LuaScript {
     pub fn on_mud_input(&self, line: &mut Line) {
         if !line.flags.bypass_script {
             let mut lline = LuaLine::from(line.clone());
-            self.exec_lua(&mut || -> LuaResult<()> {
+            let res = self.exec_lua(&mut || -> LuaResult<()> {
                 let table: mlua::Table =
                     self.state.named_registry_value(MUD_INPUT_LISTENER_TABLE)?;
                 for pair in table.pairs::<mlua::Value, mlua::Function>() {
@@ -262,6 +262,9 @@ impl LuaScript {
                 }
                 Ok(())
             });
+            if res.is_none() {
+                line.flags.matched = true;
+            }
         }
     }
 


### PR DESCRIPTION
If an input listener errors, it should be considered to have matched the line.

Otherwise, any error in the input listener will cause the input to be sent to the MUD. Even if the input listener shouldn't actually match the line, it is probably best to just not send data to the MUD when an error occurred.

Fixes #643