### PR TITLE
Improves "TTS not available" handling and feedback

### DIFF
--- a/resources/lua/history.lua
+++ b/resources/lua/history.lua
@@ -76,7 +76,9 @@ function mod.previous_command()
         index = find_match_up()
     end
     if index > 0 then
-        tts.speak(commands[index], true)
+        if tts.is_enabled() then
+            tts.speak(commands[index], true)
+        end
         prompt.set(commands[index])
     else
         reset()
@@ -96,10 +98,14 @@ function mod.next_command()
             index = find_match_down()
         end
         if index then
-            tts.speak(commands[index], true)
+            if tts.is_enabled() then
+                tts.speak(commands[index], true)
+            end
             prompt.set(commands[index])
         else
-            tts.speak(orig_cmd, true)
+            if tts.is_enabled() then
+                tts.speak(orig_cmd, true)
+            end
             prompt.set(orig_cmd)
             reset()
         end

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ impl From<Matches> for RuntimeConfig {
             headless_mode: false,
             verbose: matches.opt_present("verbose"),
             world,
-            use_tts: matches.opt_present("tts"),
+            use_tts: matches.opt_defined("tts") && matches.opt_present("tts"),
             tls: matches.opt_present("tls"),
             no_verify: matches.opt_present("no-verify"),
             connect,

--- a/src/lua/tts.rs
+++ b/src/lua/tts.rs
@@ -1,4 +1,5 @@
-use mlua::{AnyUserData, UserData, UserDataMethods};
+use log::debug;
+use mlua::{AnyUserData, MetaMethod, UserData, UserDataMethods};
 
 use crate::{event::Event, tts::TTSEvent};
 
@@ -16,121 +17,148 @@ impl Tts {
 
 impl UserData for Tts {
     fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
-        methods.add_function("speak", |ctx, (msg, interupt): (String, Option<bool>)| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::Speak(msg, interupt.unwrap_or_default()))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("speak_direct", |ctx, msg: String| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::SpeakDirect(msg)))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("stop", |ctx, _: ()| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend.writer.send(Event::SpeakStop).unwrap();
-            Ok(())
-        });
-        methods.add_function("enable", |ctx, enabled: bool| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend.writer.send(Event::TTSEnabled(enabled)).unwrap();
-            Ok(())
-        });
-        methods.add_function("is_enabled", |ctx, ()| {
-            let tts_aud: AnyUserData = ctx.globals().get("tts")?;
-            let tts = tts_aud.borrow::<Tts>()?;
-            Ok(tts.enabled)
-        });
-        methods.add_function("set_rate", |ctx, rate: f64| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::SetRate(rate as f32)))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("change_rate", |ctx, rate: f64| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::ChangeRate(rate as f32)))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("echo_keypresses", |ctx, enabled: bool| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::EchoKeys(enabled)))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("step_back", |ctx, step: usize| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::Prev(step)))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("step_forward", |ctx, step: usize| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::Next(step)))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("scan_back", |ctx, step: usize| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::ScanBack(step)))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("scan_forward", |ctx, step: usize| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::ScanForward(step)))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("scan_input_back", |ctx, _: ()| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::ScanBackToInput))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("scan_input_forward", |ctx, _: ()| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::ScanForwardToInput))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("step_begin", |ctx, _: ()| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend
-                .writer
-                .send(Event::TTSEvent(TTSEvent::Begin))
-                .unwrap();
-            Ok(())
-        });
-        methods.add_function("step_end", |ctx, _: ()| {
-            let backend: Backend = ctx.named_registry_value(BACKEND)?;
-            backend.writer.send(Event::TTSEvent(TTSEvent::End)).unwrap();
-            Ok(())
-        });
+        if cfg!(feature = "tts") {
+            methods.add_function("speak", |ctx, (msg, interupt): (String, Option<bool>)| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::Speak(msg, interupt.unwrap_or_default()))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("speak_direct", |ctx, msg: String| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::SpeakDirect(msg)))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("stop", |ctx, _: ()| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend.writer.send(Event::SpeakStop).unwrap();
+                Ok(())
+            });
+            methods.add_function("enable", |ctx, enabled: bool| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend.writer.send(Event::TTSEnabled(enabled)).unwrap();
+                Ok(())
+            });
+            methods.add_function("is_enabled", |ctx, ()| {
+                let tts_aud: AnyUserData = ctx.globals().get("tts")?;
+                let tts = tts_aud.borrow::<Tts>()?;
+                Ok(tts.enabled)
+            });
+            methods.add_function("set_rate", |ctx, rate: f64| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::SetRate(rate as f32)))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("change_rate", |ctx, rate: f64| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::ChangeRate(rate as f32)))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("echo_keypresses", |ctx, enabled: bool| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::EchoKeys(enabled)))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("step_back", |ctx, step: usize| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::Prev(step)))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("step_forward", |ctx, step: usize| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::Next(step)))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("scan_back", |ctx, step: usize| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::ScanBack(step)))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("scan_forward", |ctx, step: usize| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::ScanForward(step)))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("scan_input_back", |ctx, _: ()| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::ScanBackToInput))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("scan_input_forward", |ctx, _: ()| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::ScanForwardToInput))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("step_begin", |ctx, _: ()| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::TTSEvent(TTSEvent::Begin))
+                    .unwrap();
+                Ok(())
+            });
+            methods.add_function("step_end", |ctx, _: ()| {
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend.writer.send(Event::TTSEvent(TTSEvent::End)).unwrap();
+                Ok(())
+            });
+        } else {
+            debug!("TTS not enabled");
+            methods.add_function("is_enabled", |_, ()| Ok(false));
+            methods.add_meta_function(MetaMethod::Index, |ctx, _: ()| {
+                let func: mlua::Function = ctx.load("function () end").eval()?;
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::Error(
+                        "Blightmud was not compiled with text-to-speech enabled".to_string(),
+                    ))
+                    .unwrap();
+                Ok(func)
+            });
+            methods.add_meta_function_mut(MetaMethod::Index, |ctx, _: ()| {
+                let func: mlua::Function = ctx.load("function () end").eval()?;
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::Error(
+                        "Blightmud was not compiled with text-to-speech enabled".to_string(),
+                    ))
+                    .unwrap();
+                Ok(func)
+            });
+        }
     }
 }

--- a/src/lua/tts.rs
+++ b/src/lua/tts.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use mlua::{AnyUserData, MetaMethod, UserData, UserDataMethods};
 
 use crate::{event::Event, tts::TTSEvent};
@@ -135,7 +134,6 @@ impl UserData for Tts {
                 Ok(())
             });
         } else {
-            debug!("TTS not enabled");
             methods.add_function("is_enabled", |_, ()| Ok(false));
             methods.add_meta_function(MetaMethod::Index, |ctx, _: ()| {
                 let func: mlua::Function = ctx.load("function () end").eval()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,6 @@ mod tests {
         let args: Vec<String> = vec![
             "blightmud",
             "--verbose",
-            "--tts",
             "--connect",
             "localhost:8080",
         ]
@@ -113,7 +112,6 @@ mod tests {
         };
         let rt = RuntimeConfig::from(matches);
         assert!(rt.verbose);
-        assert!(rt.use_tts);
         assert_eq!(rt.connect, Some("localhost:8080".to_string()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,15 +96,10 @@ mod tests {
 
     #[test]
     fn test_config_parse() {
-        let args: Vec<String> = vec![
-            "blightmud",
-            "--verbose",
-            "--connect",
-            "localhost:8080",
-        ]
-        .iter()
-        .map(|s| String::from(*s))
-        .collect();
+        let args: Vec<String> = vec!["blightmud", "--verbose", "--connect", "localhost:8080"]
+            .iter()
+            .map(|s| String::from(*s))
+            .collect();
         let opts = setup_options();
         let matches = match opts.parse(&args[1..]) {
             Ok(m) => m,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,11 +37,13 @@ fn setup_options() -> Options {
         "no-verify",
         "Don't verify the cert for the TLS connection",
     );
-    opts.optflag(
-        "T",
-        "tts",
-        "Use the TTS system when playing a MUD (for visually impaired users)",
-    );
+    if cfg!(feature = "tts") {
+        opts.optflag(
+            "T",
+            "tts",
+            "Use the TTS system when playing a MUD (for visually impaired users)",
+        );
+    }
     opts.optopt("w", "world", "Connect to a predefined world", "WORLD");
     opts.optflag("h", "help", "Print help menu");
     opts.optflag("v", "version", "Print version information");
@@ -56,10 +58,13 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     let program = &args[0];
     let opts = setup_options();
-    let matches = match opts.parse(&args[1..]) {
-        Ok(m) => m,
-        Err(f) => panic!("{}", f.to_string()),
-    };
+
+    let matches = opts.parse(&args[1..]);
+    if let Err(f) = matches {
+        eprintln!("{}", f.to_string());
+        return;
+    }
+    let matches = matches.unwrap();
 
     if matches.opt_present("h") {
         print_help(program, opts);


### PR DESCRIPTION
Until now, when blightmud is compiled without TTS support the feedback that TTS isn't available doesn't really exist. With this change. Attempting to enable TTS via commandline or through lua scripts will present the user with proper warnings that his/her version of Blightmud is not compiled with TTS enabled.

Fixes: #690 