### PR TITLE
feat: RFC 1073 (NAWS), on_dimensions_change callbacks.

### DIFF
--- a/resources/help/core.md
+++ b/resources/help/core.md
@@ -11,7 +11,7 @@ they should not be needed.
 
 ***core.enable_protocol(proto)***
 Makes Blightmud respond with `IAC DO PROTO` if the server asks for it.  Take
-not that this method is best called before a client actually connects to a mud.
+note that this method is best called before a client actually connects to a mud.
 All servers don't play as nice if the client isn't quick to respond to a `IAC
 WILL PROTO`.
 

--- a/resources/help/lua_blight.md
+++ b/resources/help/lua_blight.md
@@ -32,6 +32,19 @@ width, height = blight.terminal_dimensions()
 
 ##
 
+***blight.on_dimensions_change(callback: function(width: int, height: int) -> nil)***
+Registers a callback function to be called when the terminal dimensions change.
+The callback function will receive the updated terminal width and height as
+arguments.
+
+```lua
+blight.on_dimensions_change(function (width, height)
+    print("Terminal is now ".. width .. "x".. height)
+end)
+```
+
+##
+
 ***blight.is_reader_mode() -> bool***
 Returns true or false depending on if reader mode is enabled or not.
 

--- a/resources/lua/naws.lua
+++ b/resources/lua/naws.lua
@@ -1,0 +1,43 @@
+-- See https://www.rfc-editor.org/rfc/rfc1073.html
+local NAWS_PROTOCOL = 31
+local naws_enabled = false
+
+-- Return table with the network byte order (e.g. big endian) encoding of the
+-- width and height given.
+local function network_dimensions(width, height)
+    bytes = {}
+    local append_byte = function(c)
+        table.insert(bytes, string.byte(c))
+    end
+    string.pack(">i2", width):gsub(".", append_byte)
+    string.pack(">i2", height):gsub(".", append_byte)
+    return bytes
+end
+
+local function send_dimensions(width, height)
+    -- We must adjust the height to just the writable area, subtracting
+    -- the size by 2 for the input/prompt area, and by the size of the status
+    -- area.
+    height = height - 2 - blight.status_height()
+    core.subneg_send(NAWS_PROTOCOL, network_dimensions(width, height))
+end
+
+-- Advertise NAWS support.
+core.enable_protocol(NAWS_PROTOCOL)
+
+-- If NAWS is negotiated update our enabled status and send the current
+-- window dimensions.
+core.on_protocol_enabled(function (proto)
+    if proto == NAWS_PROTOCOL then
+        mud.add_tag("NAWS")
+        naws_enabled = true
+        send_dimensions(blight.terminal_dimensions())
+    end
+end)
+
+-- When dimensions change, send an updated NAWS message when enabled.
+blight.on_dimensions_change(function (width, height)
+    if naws_enabled then
+        send_dimensions(width, height)
+    end
+end)

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -149,6 +149,15 @@ impl UserData for Blight {
                 Ok(())
             },
         );
+        methods.add_function(
+            "on_dimensions_change",
+            |ctx, func: Function| -> mlua::Result<()> {
+                let table: Table =
+                    ctx.named_registry_value(BLIGHT_ON_DIMENSIONS_CHANGE_LISTENER_TABLE)?;
+                table.set(table.raw_len() + 1, func)?;
+                Ok(())
+            },
+        );
         methods.add_function("quit", |ctx, ()| {
             let this_aux = ctx.globals().get::<_, AnyUserData>("blight")?;
             let this = this_aux.borrow::<Blight>()?;
@@ -193,8 +202,8 @@ mod test_blight {
 
     use super::Blight;
     use crate::lua::constants::{
-        BLIGHT_ON_QUIT_LISTENER_TABLE, COMMAND_BINDING_TABLE, COMPLETION_CALLBACK_TABLE,
-        STATUS_AREA_HEIGHT,
+        BLIGHT_ON_DIMENSIONS_CHANGE_LISTENER_TABLE, BLIGHT_ON_QUIT_LISTENER_TABLE,
+        COMMAND_BINDING_TABLE, COMPLETION_CALLBACK_TABLE, STATUS_AREA_HEIGHT,
     };
     use crate::{PROJECT_NAME, VERSION};
 
@@ -207,6 +216,11 @@ mod test_blight {
         lua.globals().set("blight", blight).unwrap();
         lua.set_named_registry_value(BLIGHT_ON_QUIT_LISTENER_TABLE, lua.create_table().unwrap())
             .unwrap();
+        lua.set_named_registry_value(
+            BLIGHT_ON_DIMENSIONS_CHANGE_LISTENER_TABLE,
+            lua.create_table().unwrap(),
+        )
+        .unwrap();
         lua.set_named_registry_value(COMPLETION_CALLBACK_TABLE, lua.create_table().unwrap())
             .unwrap();
         lua.set_named_registry_value(COMMAND_BINDING_TABLE, lua.create_table().unwrap())

--- a/src/lua/constants.rs
+++ b/src/lua/constants.rs
@@ -10,6 +10,7 @@ pub const COMMAND_BINDING_TABLE: &str = "__cmd_binds";
 pub const MUD_OUTPUT_LISTENER_TABLE: &str = "__output_listeners";
 pub const MUD_INPUT_LISTENER_TABLE: &str = "__input_listeners";
 pub const BLIGHT_ON_QUIT_LISTENER_TABLE: &str = "__on_quit_listeners";
+pub const BLIGHT_ON_DIMENSIONS_CHANGE_LISTENER_TABLE: &str = "__on_dimensions_change_listeners";
 pub const BACKEND: &str = "__blight_backend_wrapper";
 pub const CONNECTION_ID: &str = "__blight_connection_id";
 pub const COMPLETION_CALLBACK_TABLE: &str = "__completion_callback_table";


### PR DESCRIPTION
This PR adds support for Telnet "Negotiate About Window Size" (NAWS) negotiation support. See [RFC 1073](https://www.rfc-editor.org/rfc/rfc1073.html) for details.

This protocol extension allows Blightmud to communicate terminal size information to compatible MUD servers. This in turn allows servers to better size output for clients, particularly when rendering rich terminal interfaces. For Blightmud, we take care to subtract the input area and status area heights from the height transmitted to the server in NAWS so that only the drawable area is reported.

To support this feature the `blight` Lua module is updated to allow registering callbacks to be invoked whenever terminal dimensions change (`blight.on_dimensions_change`). Registered callbacks get invoked with the new terminal width/height as arguments and the NAWS module uses such a callback to update the server on the client's terminal size whenever it changes (iff NAWS has been negotiated).

