### PR TITLE
deps: update ndk-sys 0.4.0 -> 0.4.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,7 +1605,7 @@ checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
  "bitflags",
  "jni-sys",
- "ndk-sys 0.4.0",
+ "ndk-sys 0.4.1+23.1.7779620",
  "num_enum",
  "raw-window-handle",
  "thiserror",
@@ -1628,7 +1628,7 @@ dependencies = [
  "ndk 0.7.0",
  "ndk-context",
  "ndk-macro",
- "ndk-sys 0.4.0",
+ "ndk-sys 0.4.1+23.1.7779620",
  "once_cell",
  "parking_lot",
 ]
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "ndk-sys"
-version = "0.4.0"
+version = "0.4.1+23.1.7779620"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d83ec9c63ec5bf950200a8e508bdad6659972187b625469f58ef8c08e29046"
+checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
 dependencies = [
  "jni-sys",
 ]


### PR DESCRIPTION
[`ndk-sys`](https://github.com/rust-mobile/ndk) 0.4.0 is a transitive dependency of Blightmud. Unfortunately a known issue with the cargo registry and how it applies semver has left the `ndk-sys` crate producing checksum mismatch errors between a 0.4.0 release and a yanked 0.4.0+25.0.8775105 release (https://github.com/rust-lang/cargo/issues/11412). This manifest as the build error:

    Failed to verify checksum of ndk-sys v0.4.0

The author of the ndk-sys crate has published a 0.4.1 release that should resolve this build error. This PR updates the `Cargo.lock` to use this version and I can confirm it fixes the error I observed testing the Nixpkgs Blightmud derivation with the tip of `dev`.