### PR TITLE
gmcp: fix Core.Hello data key capitalization.

### DIFF
--- a/resources/lua/gmcp.lua
+++ b/resources/lua/gmcp.lua
@@ -36,8 +36,8 @@ local function GMCP()
             store.session_write("__gmcp_ready", "true")
             local program, version = blight.version()
             local hello_obj = {
-                Version=version,
-                Client=program,
+                version=version,
+                client=program,
             }
             core.subneg_send(201, string_to_bytes("Core.Hello " .. json.encode(hello_obj)))
             for _,cb in ipairs(self.ready_listeners) do

--- a/tests/communication_tests.rs
+++ b/tests/communication_tests.rs
@@ -51,11 +51,11 @@ fn test_gmcp_negotiation() -> std::io::Result<()> {
     connection.send(&[IAC, WILL, GMCP]);
     assert_eq!(connection.read(3), &[IAC, DO, GMCP]);
     let expected1 = format!(
-        "Core.Hello {{\"Version\":\"{}\",\"Client\":\"{}\"}}",
+        "Core.Hello {{\"version\":\"{}\",\"client\":\"{}\"}}",
         VERSION, PROJECT_NAME
     );
     let expected2 = format!(
-        "Core.Hello {{\"Client\":\"{}\",\"Version\":\"{}\"}}",
+        "Core.Hello {{\"client\":\"{}\",\"version\":\"{}\"}}",
         PROJECT_NAME, VERSION
     );
     let alt1 = vec![


### PR DESCRIPTION
Conventionally ([0],[1],[2],[3]) the keys of the Core.Hello GMCP message are lowercase. Prior to this PR Blightmud used title-case for the version and client keys, causing some compat issues.

This PR updates the gmcp.lua resource and associated test to send the Core.Hello data with lowercase keys.

Resolves #714 

[0]: https://github.com/keneanung/GMCPAdditions#core
[1]: https://mume.org/help/generic_mud_communication_protocol
[2]: https://discworld.starturtle.net/lpc/playing/documentation.c?path=/concepts/gmcp
[3]: https://www.aardwolf.com/wiki/index.php/Clients/GMCP