### PR TITLE
prompt: add add_prompt_listener function.

### DIFF
--- a/resources/help/prompt.md
+++ b/resources/help/prompt.md
@@ -12,3 +12,18 @@ Returns the line currently typed into the prompt
 
 ***prompt.set(input)***
 Sets the line typed in the prompt. Replacing any current data.
+
+##
+
+***prompt.add_prompt_listener(callback)***
+Registers a callback that is triggered when data has been typed on the prompt
+line, or set with `prompt.set`.
+
+- `callback`   A Lua function to be called each prompt line update. (line)
+
+```lua
+blight.add_prompt_listener(function (line)
+    blight.output("Prompt buffer is currently:", line)
+end)
+```
+

--- a/src/event.rs
+++ b/src/event.rs
@@ -280,6 +280,9 @@ impl EventHandler {
                 Ok(())
             }
             Event::UserInputBuffer(input_buffer, pos) => {
+                if let Ok(script) = self.session.lua_script.lock() {
+                    script.on_prompt_update(&input_buffer);
+                }
                 let mut prompt_input = self.session.prompt_input.lock().unwrap();
                 *prompt_input = input_buffer;
                 screen.print_prompt_input(&prompt_input, pos);

--- a/src/lua/constants.rs
+++ b/src/lua/constants.rs
@@ -15,6 +15,7 @@ pub const BACKEND: &str = "__blight_backend_wrapper";
 pub const CONNECTION_ID: &str = "__blight_connection_id";
 pub const COMPLETION_CALLBACK_TABLE: &str = "__completion_callback_table";
 pub const PROMPT_CONTENT: &str = "__prompt_content";
+pub const PROMPT_INPUT_LISTENER_TABLE: &str = "__prompt_listeners";
 pub const FS_LISTENERS: &str = "__fs_listeners";
 pub const SCRIPT_RESET_LISTENERS: &str = "__script_reset_listeners";
 pub const STATUS_AREA_HEIGHT: &str = "__status_area_height";

--- a/src/lua/prompt.rs
+++ b/src/lua/prompt.rs
@@ -1,10 +1,10 @@
-use mlua::UserData;
+use mlua::{Function, Table, UserData};
 
 use crate::event::Event;
 
 use super::{
     backend::Backend,
-    constants::{BACKEND, PROMPT_CONTENT},
+    constants::{BACKEND, PROMPT_CONTENT, PROMPT_INPUT_LISTENER_TABLE},
 };
 
 #[derive(Debug, Clone)]
@@ -24,5 +24,13 @@ impl UserData for Prompt {
         methods.add_function("get", |ctx, ()| -> mlua::Result<String> {
             ctx.named_registry_value(PROMPT_CONTENT)
         });
+        methods.add_function(
+            "add_prompt_listener",
+            |ctx, func: Function| -> mlua::Result<()> {
+                let table: Table = ctx.named_registry_value(PROMPT_INPUT_LISTENER_TABLE)?;
+                table.set(table.raw_len() + 1, func)?;
+                Ok(())
+            },
+        );
     }
 }


### PR DESCRIPTION
This branch adds a new `add_prompt_listener` function to the Lua prompt module. This function allows registering a callback that will be invoked whenever the input prompt buffer area is updated (either by the user typing, or from `prompt.set()` being invoked).

In the future this may be useful for performing tasks like spellchecking of data entered in the prompt area but not yet sent to the server.