### PR TITLE
feat: add Lua APIs for prompt input masking.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +263,7 @@ dependencies = [
  "termion",
  "timer",
  "tts",
+ "vte 0.11.0",
 ]
 
 [[package]]
@@ -2891,7 +2898,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
 dependencies = [
- "vte",
+ "vte 0.10.1",
 ]
 
 [[package]]
@@ -3334,7 +3341,18 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aae21c12ad2ec2d168c236f369c38ff332bc1134f7246350dca641437365045"
+dependencies = [
+ "arrayvec 0.7.2",
  "utf8parse",
  "vte_generate_state_changes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ signal-hook = "0.3.14"
 mlua =  { version = "0.8.7", features = ["lua54", "send", "vendored"] }
 regex = "1.7.1"
 strip-ansi-escapes = "0.1.1"
+vte = "0.11.0"
 timer = "0.2.0"
 flate2 = "1.0.25"
 mdcat = { version = "1.0.0", default-features = false }

--- a/resources/help/prompt.md
+++ b/resources/help/prompt.md
@@ -1,7 +1,9 @@
 # Prompt
 
 This module offers methods to interact with data that has
-been typed on the prompt line
+been typed on the prompt line.
+
+See also `/help prompt_mask`.
 
 ##
 

--- a/resources/help/prompt_mask.md
+++ b/resources/help/prompt_mask.md
@@ -1,0 +1,52 @@
+# Prompt Mask
+
+This module offers methods to mask (decorate) data that has
+been typed on the prompt line but not yet sent to the server.
+
+See also `/help prompt`.
+
+##
+
+***prompt_mask.set(data, table) -> bool***
+Set the prompt mask table to be associated with the input data. Returns true
+if the mask is valid, and the prompt data hasn't changed. Returns false if
+the mask is not valid, or the prompt data has changed and no longer matches
+the data argument.
+
+Multiple calls to `prompt_mask.set` will merge the tables, with colliding 
+keys having their value replaced by the value from the last call.
+
+- `data`    Prompt data to mask. Must match current prompt input data.
+- `table`   A Lua table of integer index keys and mask content values.
+            Each index must be a valid character index within the bounds
+            of data (1-indexed) and must fall at a character boundary.
+
+
+```lua
+-- Example: Highlight any lines that start with a dangerous command.
+prompt.add_prompt_listener(function()
+    local danger = "/quit"
+    local data = prompt.get()
+    if #data < #danger or string.sub(data, 1, #danger) ~= danger then
+        return
+    end
+    local danger_mask = {[1] = BG_RED, [#data+1] = C_RESET};
+    local res = prompt_mask.set(data, danger_mask);
+    blight.output(string.format("masked: %s",res))
+end)
+```
+
+##
+
+***prompt_mask.clear()***
+Clear the current prompt mask table (if any).
+
+##
+
+***prompt_mask.get() -> table***
+Return the current prompt mask table (if any).
+
+- `table`   A Lua table of integer index keys and mask content values
+            previously set with calls to `prompt_mask.set`.
+            Each index key will be a character index within the bounds
+            of the current prompt input data (1-indexed).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,9 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
             | Event::Info(_)
             | Event::AddTag(_)
             | Event::ClearTags
-            | Event::UserInputBuffer(_, _) => {
+            | Event::UserInputBuffer(_, _)
+            | Event::SetPromptMask(_)
+            | Event::ClearPromptMask => {
                 //tts_ctrl.handle_events(event.clone());
                 event_handler.handle_output_events(event, &mut screen)?;
             }

--- a/src/lua/constants.rs
+++ b/src/lua/constants.rs
@@ -15,6 +15,7 @@ pub const BACKEND: &str = "__blight_backend_wrapper";
 pub const CONNECTION_ID: &str = "__blight_connection_id";
 pub const COMPLETION_CALLBACK_TABLE: &str = "__completion_callback_table";
 pub const PROMPT_CONTENT: &str = "__prompt_content";
+pub const PROMPT_MASK_CONTENT: &str = "__prompt_mask_content";
 pub const PROMPT_INPUT_LISTENER_TABLE: &str = "__prompt_listeners";
 pub const FS_LISTENERS: &str = "__fs_listeners";
 pub const SCRIPT_RESET_LISTENERS: &str = "__script_reset_listeners";

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -18,6 +18,7 @@ mod lua_script;
 mod mud;
 mod plugin;
 mod prompt;
+mod prompt_mask;
 mod regex;
 mod script;
 mod servers;

--- a/src/lua/prompt_mask.rs
+++ b/src/lua/prompt_mask.rs
@@ -1,0 +1,174 @@
+use mlua::{Result as LuaResult, String as LuaString, Table, UserData};
+
+use super::{
+    backend::Backend,
+    constants::{BACKEND, PROMPT_CONTENT, PROMPT_MASK_CONTENT},
+};
+use crate::event::Event;
+use crate::model;
+
+#[derive(Debug, Clone)]
+pub struct PromptMask {}
+
+impl UserData for PromptMask {
+    fn add_methods<'lua, M: mlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
+        methods.add_function(
+            "set",
+            |ctx, (data, mask): (LuaString, Table)| -> LuaResult<bool> {
+                let prompt_data: String = ctx.named_registry_value(PROMPT_CONTENT).unwrap();
+                let mask_data = data.to_str().unwrap();
+                if prompt_data != mask_data {
+                    return Ok(false);
+                }
+                let prompt_mask = model::PromptMask::from(mask);
+                for (offset, _) in prompt_mask.iter() {
+                    let offset = *offset as usize;
+                    if offset as usize > prompt_data.len() + 1 {
+                        return Ok(false);
+                    }
+                    if !prompt_data.is_char_boundary(offset as usize) {
+                        return Ok(false);
+                    }
+                }
+                let backend: Backend = ctx.named_registry_value(BACKEND)?;
+                backend
+                    .writer
+                    .send(Event::SetPromptMask(prompt_mask))
+                    .unwrap();
+                Ok(true)
+            },
+        );
+        methods.add_function("clear", |ctx, ()| -> LuaResult<()> {
+            let backend: Backend = ctx.named_registry_value(BACKEND)?;
+            backend.writer.send(Event::ClearPromptMask).unwrap();
+            Ok(())
+        });
+        methods.add_function("get", |ctx, ()| -> LuaResult<Table> {
+            ctx.named_registry_value(PROMPT_MASK_CONTENT)
+        });
+    }
+}
+
+#[cfg(test)]
+mod test_prompt_mask {
+    use crate::event::Event;
+    use crate::lua::backend::Backend;
+    use crate::lua::constants::{BACKEND, PROMPT_CONTENT, PROMPT_MASK_CONTENT};
+    use crate::lua::prompt_mask::PromptMask;
+    use crate::model;
+    use mlua::{Lua, Table};
+    use std::collections::BTreeMap;
+    use std::sync::mpsc::{channel, Receiver, Sender};
+
+    fn get_lua_state(prompt_content: &str) -> (Lua, Receiver<Event>) {
+        let lua = Lua::new();
+        let (writer, reader): (Sender<Event>, Receiver<Event>) = channel();
+        let backend = Backend { writer };
+        let prompt_mask = PromptMask {};
+        lua.globals().set("prompt_mask", prompt_mask).unwrap();
+        lua.set_named_registry_value(PROMPT_CONTENT, prompt_content)
+            .unwrap();
+        lua.set_named_registry_value(BACKEND, backend).unwrap();
+        (lua, reader)
+    }
+
+    #[test]
+    fn test_set_mask_valid() {
+        let prompt_state = "hi hello bye";
+        let (lua, reader) = get_lua_state(prompt_state);
+        let mut expected_map = BTreeMap::new();
+        // Note: we expect the loaded mask's indexes to have been converted to 0-indexing.
+        expected_map.insert(3, "*".to_string());
+        expected_map.insert(5, "*".to_string());
+        let expected_mask = model::PromptMask::from(expected_map);
+        let test_script = format!(
+            r#"
+    local good_mask = {{ 
+      [4] = "*", [6] = "*"
+    }}
+    mask_set = prompt_mask.set({:?}, good_mask)
+"#,
+            prompt_state
+        );
+        lua.load(test_script.as_str()).exec().unwrap();
+        let mask_set: bool = lua.globals().get("mask_set").unwrap();
+        assert_eq!(mask_set, true);
+        assert_eq!(reader.recv(), Ok(Event::SetPromptMask(expected_mask)));
+    }
+
+    #[test]
+    fn test_set_mask_data_stale() {
+        let prompt_state = "initial prompt input";
+        let (lua, reader) = get_lua_state(prompt_state);
+        let test_script = r#"
+    local good_mask = {{ [7] = "!" }}
+    -- NOTE: data arg doesn't match prompt_state.
+    mask_set = prompt_mask.set("diff. prompt input", good_mask)
+"#;
+        lua.load(test_script).exec().unwrap();
+        let mask_set: bool = lua.globals().get("mask_set").unwrap();
+        assert_eq!(mask_set, false);
+        assert!(reader.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_set_mask_index_oob() {
+        let prompt_state = "hello";
+        let (lua, reader) = get_lua_state(prompt_state);
+        let test_script = format!(
+            r#"
+    -- NOTE: Index is out of bounds for current prompt state.
+    local bad_mask = {{ [999] = "!" }}
+    mask_set = prompt_mask.set({:?}, bad_mask)
+"#,
+            prompt_state
+        );
+        lua.load(test_script.as_str()).exec().unwrap();
+        let mask_set: bool = lua.globals().get("mask_set").unwrap();
+        assert_eq!(mask_set, false);
+        assert!(reader.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_set_mask_index_not_char_boundary() {
+        let prompt_state = "hi 😇 bye";
+        let (lua, reader) = get_lua_state(prompt_state);
+        let test_script = format!(
+            r#"
+    -- NOTE: Index 5 falls inside of the multi-byte emoji and should fail a is_char_boundary test.
+    local bad_mask = {{ [5] = "!" }}
+    mask_set = prompt_mask.set({:?}, bad_mask)
+"#,
+            prompt_state
+        );
+        lua.load(test_script.as_str()).exec().unwrap();
+        let mask_set: bool = lua.globals().get("mask_set").unwrap();
+        assert_eq!(mask_set, false);
+        assert!(reader.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_clear_mask() {
+        let (lua, reader) = get_lua_state("");
+        lua.load("prompt_mask.clear()").exec().unwrap();
+        assert_eq!(reader.recv(), Ok(Event::ClearPromptMask));
+    }
+
+    #[test]
+    fn test_get_mask() {
+        let (lua, _reader) = get_lua_state("just some test content");
+
+        let mut mask_map = BTreeMap::new();
+        mask_map.insert(10, "hi".to_string());
+        mask_map.insert(20, "bye".to_string());
+        let mask = model::PromptMask::from(mask_map);
+
+        lua.set_named_registry_value(PROMPT_MASK_CONTENT, mask.to_table(&lua).unwrap())
+            .unwrap();
+        lua.load("mask = prompt_mask.get()").exec().unwrap();
+        let result = lua.globals().get::<_, Table>("mask").unwrap();
+
+        assert_eq!(result.get::<i32, String>(11).unwrap(), "hi");
+        assert_eq!(result.get::<i32, String>(21).unwrap(), "bye");
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,10 +1,13 @@
 mod completions;
 mod connection;
 mod line;
+mod prompt_mask;
 mod regex;
 mod settings;
+
 pub use self::{regex::Regex, regex::RegexOptions};
 pub use completions::Completions;
 pub use connection::{Connection, Servers};
 pub use line::Line;
+pub use prompt_mask::PromptMask;
 pub use settings::*;

--- a/src/model/prompt_mask.rs
+++ b/src/model/prompt_mask.rs
@@ -1,0 +1,147 @@
+use mlua::{Integer as LuaInt, Lua, Result as LuaResult, String as LuaString, Table as LuaTable};
+use std::collections::BTreeMap;
+use std::ops::{AddAssign, Deref};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct PromptMask {
+    mask: BTreeMap<i32, String>,
+}
+
+impl PromptMask {
+    pub fn new() -> Self {
+        PromptMask {
+            mask: BTreeMap::new(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.mask.clear()
+    }
+
+    pub fn mask_buffer(&self, buf: &[char]) -> String {
+        let mut masked_buf = buf.to_owned();
+        let mut offset = 0;
+        for (idx, mask) in self.iter() {
+            let adjusted_idx = offset + *idx as usize;
+            masked_buf.splice(adjusted_idx..adjusted_idx, mask.chars());
+            offset += mask.len();
+        }
+
+        masked_buf.iter().collect()
+    }
+
+    pub fn to_table<'a>(&'a self, ctx: &'a Lua) -> LuaResult<LuaTable> {
+        let table = ctx.create_table()?;
+        for (idx, mask) in self.iter() {
+            let adjusted_idx = *idx + 1;
+            table.set(adjusted_idx, (*mask).clone())?;
+        }
+        Ok(table)
+    }
+}
+
+impl Deref for PromptMask {
+    type Target = BTreeMap<i32, String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.mask
+    }
+}
+
+impl AddAssign for PromptMask {
+    fn add_assign(&mut self, rhs: Self) {
+        self.mask.extend(rhs.mask)
+    }
+}
+
+impl From<BTreeMap<i32, String>> for PromptMask {
+    fn from(mask: BTreeMap<i32, String>) -> Self {
+        PromptMask { mask }
+    }
+}
+
+impl From<LuaTable<'_>> for PromptMask {
+    fn from(mask_table: LuaTable) -> Self {
+        let mut mask = BTreeMap::new();
+        for pair in mask_table.pairs::<LuaInt, LuaString>() {
+            let (offset, marker) = pair.unwrap();
+            // Lua is 1-indexed, we handle that here as part of the conversion from LuaTable.
+            // so that the Rust code can use natural 0-indexing.
+            let adjusted_offset = (offset as i32) - 1;
+            mask.insert(adjusted_offset as i32, marker.to_str().unwrap().to_string());
+        }
+        PromptMask { mask }
+    }
+}
+
+#[cfg(test)]
+mod test_prompt_mask {
+    use crate::model::PromptMask;
+    use mlua::{Lua, Table as LuaTable};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn test_from_luatable() {
+        let lua = Lua::new();
+        let simple_mask: LuaTable = lua
+            .load(
+                r#"
+    {
+        [5] = "!",
+        [1] = "*",
+    }
+"#,
+            )
+            .eval()
+            .unwrap();
+        let mut expected = BTreeMap::new();
+        // We expect the 1-indexed Lua table indices to have been translated to 0-indexing.
+        expected.insert(0, "*".to_string());
+        expected.insert(4, "!".to_string());
+
+        let lua_mask = PromptMask::from(simple_mask);
+        let expected_mask = PromptMask::from(expected);
+        assert_eq!(lua_mask, expected_mask)
+    }
+
+    #[test]
+    fn test_add_assign() {
+        let mut mask_map_a = BTreeMap::new();
+        mask_map_a.insert(10, "*".to_string());
+        mask_map_a.insert(15, "#".to_string());
+        mask_map_a.insert(20, "!".to_string());
+        let mut mask_a = PromptMask::from(mask_map_a);
+
+        let mut mask_map_b = BTreeMap::new();
+        mask_map_b.insert(1, "@".to_string());
+        mask_map_b.insert(15, "%".to_string());
+        mask_map_b.insert(25, "&".to_string());
+        let mask_b = PromptMask::from(mask_map_b);
+
+        let mut expected_map = BTreeMap::new();
+        expected_map.insert(1, "@".to_string());
+        expected_map.insert(10, "*".to_string());
+        expected_map.insert(15, "%".to_string()); // NB: overwritten by map_b.
+        expected_map.insert(20, "!".to_string());
+        expected_map.insert(25, "&".to_string());
+        let expected = PromptMask::from(expected_map);
+
+        mask_a += mask_b;
+        assert_eq!(mask_a, expected)
+    }
+
+    #[test]
+    fn test_masking() {
+        let buf = vec![
+            't', 'h', 'i', 's', ' ', 'i', 's', ' ', 'i', 'm', 'p', 'o', 'r', 't', 'a', 'n', 't',
+            ',', ' ', 'o', 'k',
+        ];
+        let mut mask_map = BTreeMap::new();
+        mask_map.insert(8, "*".to_string());
+        mask_map.insert(17, "*".to_string());
+        let mask = PromptMask::from(mask_map);
+
+        let res = mask.mask_buffer(&buf);
+        assert_eq!(res, "this is *important*, ok")
+    }
+}

--- a/src/ui/help_handler.rs
+++ b/src/ui/help_handler.rs
@@ -223,6 +223,7 @@ fn load_files() -> HashMap<&'static str, &'static str> {
         "ttype" => "ttype.md",
         "json" => "json.md",
         "prompt" => "prompt.md",
+        "prompt_mask" => "prompt_mask.md",
         "history" => "history.md",
         "script_example" => "scripte_example.md"
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,6 +18,7 @@ mod command;
 mod headless_screen;
 mod help_handler;
 mod history;
+mod printable_chars;
 mod reader_screen;
 mod scroll_data;
 mod split_screen;

--- a/src/ui/printable_chars.rs
+++ b/src/ui/printable_chars.rs
@@ -1,0 +1,148 @@
+extern crate vte;
+
+use std::str::{CharIndices, Chars};
+use vte::{Parser, Perform};
+
+pub(crate) trait PrintableCharsIterator<'a> {
+    fn printable_chars(&self) -> PrintableChars<'a>;
+    fn printable_char_indices(&self) -> PrintableCharIndices<'a>;
+}
+
+impl<'a> PrintableCharsIterator<'a> for &'a str {
+    fn printable_chars(&self) -> PrintableChars<'a> {
+        PrintableChars::new(self)
+    }
+
+    fn printable_char_indices(&self) -> PrintableCharIndices<'a> {
+        PrintableCharIndices::new(self)
+    }
+}
+
+struct Performer {
+    c: Option<char>,
+}
+
+impl Performer {
+    fn new() -> Self {
+        Performer { c: None }
+    }
+}
+
+impl Perform for Performer {
+    fn print(&mut self, c: char) {
+        self.c = Some(c)
+    }
+}
+
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+pub(crate) struct PrintableChars<'a> {
+    iter: Chars<'a>,
+    parser: Parser,
+    performer: Performer,
+}
+
+impl<'a> PrintableChars<'a> {
+    fn new(s: &'a str) -> Self {
+        PrintableChars {
+            iter: s.chars(),
+            parser: Parser::new(),
+            performer: Performer::new(),
+        }
+    }
+}
+
+impl<'a> Iterator for PrintableChars<'a> {
+    type Item = char;
+
+    #[inline]
+    fn next(&mut self) -> Option<char> {
+        let mut next = self.iter.next();
+
+        while let Some(c) = next {
+            self.parser.advance(&mut self.performer, c as u8);
+            if let Some(pc) = self.performer.c.take() {
+                return Some(pc);
+            } else {
+                next = self.iter.next();
+            }
+        }
+
+        None
+    }
+}
+
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+pub(crate) struct PrintableCharIndices<'a> {
+    iter: CharIndices<'a>,
+    parser: Parser,
+    performer: Performer,
+}
+
+impl<'a> PrintableCharIndices<'a> {
+    fn new(s: &'a str) -> Self {
+        PrintableCharIndices {
+            iter: s.char_indices(),
+            parser: Parser::new(),
+            performer: Performer::new(),
+        }
+    }
+}
+
+impl<'a> Iterator for PrintableCharIndices<'a> {
+    type Item = (usize, char);
+
+    #[inline]
+    fn next(&mut self) -> Option<(usize, char)> {
+        let mut next = self.iter.next();
+
+        while let Some((offset, c)) = next {
+            self.parser.advance(&mut self.performer, c as u8);
+            if let Some(c) = self.performer.c.take() {
+                return Some((offset, c));
+            } else {
+                next = self.iter.next();
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod test_printable_chars {
+    use crate::ui::printable_chars::PrintableCharsIterator;
+
+    const ANSI_RED: &str = "\x1b[30m";
+    const ANSI_OFF: &str = "\x1b[0m";
+
+    #[test]
+    fn test_printable_chars() {
+        let ansi_str = format!("Oh, {}hello{} there!", ANSI_RED, ANSI_OFF);
+        let printable_str = ansi_str.as_str().printable_chars().collect::<String>();
+        assert_ne!(ansi_str, printable_str);
+        assert_eq!(printable_str, "Oh, hello there!".to_string())
+    }
+
+    #[test]
+    fn test_printable_char_indices() {
+        let ansi_str = format!("Oh, {}hello{} !", ANSI_RED, ANSI_OFF);
+        let printable_indices = ansi_str
+            .as_str()
+            .printable_char_indices()
+            .collect::<Vec<(usize, char)>>();
+        let expected = vec![
+            (0, 'O'),
+            (1, 'h'),
+            (2, ','),
+            (3, ' '),
+            (9, 'h'), // NB: indices 4,5,6,7,8 are skipped for ANSI_RED.
+            (10, 'e'),
+            (11, 'l'),
+            (12, 'l'),
+            (13, 'o'),
+            (18, ' '), // NB: indices 14,15,16,17 skipped for ANSI_OFF.
+            (19, '!'),
+        ];
+        assert_eq!(printable_indices, expected)
+    }
+}

--- a/src/ui/reader_screen.rs
+++ b/src/ui/reader_screen.rs
@@ -8,7 +8,9 @@ use termion::{
 
 use crate::{
     model::{Line, Regex},
-    ui::{DisableOriginMode, ResetScrollRegion, ScrollRegion},
+    ui::{
+        printable_chars::PrintableCharsIterator, DisableOriginMode, ResetScrollRegion, ScrollRegion,
+    },
 };
 
 use super::{
@@ -212,6 +214,9 @@ impl UserInterface for ReaderScreen {
 
     // This is fancy logic to make 'tdsr' less noisy
     fn print_prompt_input(&mut self, input: &str, pos: usize) {
+        // Reader screens only operate on printable input characters (no term control sequences, e.g. ANSI colour).
+        let sanitized_input = input.printable_chars().collect::<String>();
+        let input = sanitized_input.as_str();
         let mut pos = pos;
         let width = self.width as usize;
         if let Some((existing, orig)) = &self.prompt_input {

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -4,7 +4,7 @@ use super::user_interface::TerminalSizeError;
 use super::wrap_line;
 use crate::io::SaveData;
 use crate::model::{Settings, HIDE_TOPBAR};
-use crate::{model::Line, model::Regex, ui::ansi::*};
+use crate::{model::Line, model::Regex, ui::ansi::*, ui::printable_chars::PrintableCharsIterator};
 use anyhow::Result;
 use std::collections::HashSet;
 use std::io::Write;
@@ -251,16 +251,16 @@ impl UserInterface for SplitScreen {
         let mut input = input;
         let mut pos = pos;
         let width = self.width as usize;
-        while input.chars().count() >= width && pos >= width {
-            if let Some((i, _)) = input.char_indices().nth(width) {
+        while input.printable_chars().count() >= width && pos >= width {
+            if let Some((i, _)) = input.printable_char_indices().nth(width) {
                 input = input.split_at(i).1;
             } else {
                 input = "";
             }
             pos -= width;
         }
-        if input.chars().count() >= width {
-            if let Some((i, _)) = input.char_indices().nth(width) {
+        if input.printable_chars().count() >= width {
+            if let Some((i, _)) = input.printable_char_indices().nth(width) {
                 input = input.split_at(i).0;
             }
         }


### PR DESCRIPTION
### Description

This commit adds three new Lua APIs: `prompt_mask.set`, `prompt_mask.get` and `prompt_mask.clear`.

The `prompt_mask.set` function accepts prompt data, and a table comprised of integer offsets to string content to insert into the prompt data at those locations pre-rendering. Mask content is not sent through to the MUD, or added to history data. Input wrapping is handled on the rendered prompt data as if the ANSI control characters were invisible. Reader mode avoids displaying any control characters in the prompt input buffer.

The function returns a bool indicating whether the mask was set. If false, the mask may have been invalid (out of range indexes, etc), or the prompt data may have already changed. Multiple calls to `set` will combine masks, with colliding keys having their values overwritten by the most recent `set` table.

When the input prompt buffer is changed we clear the prompt mask, ensuring that the two remain in sync. When a new prompt mask is set the prompt data is freshly rendered using the overlaid mask content.

The `prompt_mask.get` function returns the prompt mask table (if any). This is the combined view of all prior calls to `prompt_mask.set` and can be used to retrieve mask data.

The `prompt_mask.clear` function removes the prompt mask (if any) and redraws the input prompt data without masking.

The primary use-case for these APIs are to support scripts adding ANSI colour codes at predefined offsets to "highlight" words (e.g. based on a spellchecking result).

See `/help prompt_mask` for more information.

Resolves #723