### PR TITLE
feat: spellchecking API.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,8 @@ dependencies = [
  "getopts",
  "git2",
  "human-panic",
+ "hunspell-rs",
+ "hunspell-sys",
  "lazy_static",
  "libtelnet-rs",
  "log",
@@ -1180,6 +1182,27 @@ dependencies = [
  "termcolor",
  "toml",
  "uuid",
+]
+
+[[package]]
+name = "hunspell-rs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62ce29f9760b9fa35039ae56c1dd08b6fb8ce7fafc5f496083167ace157eb27"
+dependencies = [
+ "hunspell-sys",
+ "log",
+]
+
+[[package]]
+name = "hunspell-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9228605394e47acb7e5c20da4f9d8d5175fd767230e51d3095623bc5e20b7dec"
+dependencies = [
+ "bindgen 0.61.0",
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ serde_json = "1.0.93"
 git2 = "0.16.1"
 rodio = "0.16.0"
 notify-debouncer-mini = "0.2.1"
+hunspell-rs = "0.4.0"
+hunspell-sys = { version = "0.3.0", features = ['bundled'] }
 
 [dev-dependencies]
 mockall = "0.11.3"

--- a/resources/help/scripting.md
+++ b/resources/help/scripting.md
@@ -39,6 +39,7 @@ by typing `/help <module>`.
 - `prompt`      Module for interacting with the prompt and it's content
 - `prompt_mask` Module for masking/decorating input prompt content.
 - `servers`     Server storage and handling
+- `spellcheck`  Functions for low-level spellcheck operations.
 - `fs`          Filesystem monitoring
 - `ttype`       TTYPE negotiation configuration
 - `plugin`      Plugin handling

--- a/resources/help/spellcheck.md
+++ b/resources/help/spellcheck.md
@@ -1,0 +1,40 @@
+# Spellcheck
+
+This module is not a complete spellchecking solution. It provides 
+methods for scripts to check whether a word is misspelled, or to
+get suggestions for a misspelled word. Before use, the spellcheck 
+module must be initialized by providing paths to a Hunspell 
+compatible AFF file, and dictionary file (not included).
+
+Complete spellchecking functionality is available by installing 
+a plugin that uses these APIs, for example:
+
+- [Blightspell](https://github.com/cpu/blightspell)
+
+##
+
+***spellcheck.init(aff_path, dict_path)***
+Initializes spellchecking using the provided paths.
+
+- `aff_path`    path to a Hunspell affix file.
+- `dict_path`   path to a Hunspell dictionary file.
+
+##
+
+***spellcheck.check(word) -> bool***
+Checks whether the given word exists in the dictionary. If called
+before `spellcheck.init` an error will be produced.
+
+- `word`    A potentially misspelled word.
+- Returns true if the spelling is correct, otherwise false.
+
+##
+
+***spellcheck.suggest(word) -> table***
+Returns a table of suggested replacements for a misspelled word. 
+If called before `spellcheck.init` an error will be produced.
+
+- `word`    A potentially misspelled word.
+- Returns a table array consisting of candidate replacement words, in 
+  order of likelihood.
+

--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -10,6 +10,8 @@ use super::{
 use crate::lua::fs::Fs;
 use crate::lua::prompt::Prompt;
 use crate::lua::prompt_mask::PromptMask;
+use crate::lua::spellcheck;
+use crate::lua::spellcheck::Spellchecker;
 use crate::model::Completions;
 use crate::tools::util::expand_tilde;
 use crate::{event::Event, lua::servers::Servers, model, model::Line};
@@ -130,6 +132,7 @@ fn create_default_lua_state(builder: LuaScriptBuilder, store: Option<Store>) -> 
         globals.set("servers", Servers {})?;
         globals.set("prompt", Prompt {})?;
         globals.set("prompt_mask", PromptMask {})?;
+        globals.set(spellcheck::LUA_GLOBAL_NAME, Spellchecker::new())?;
 
         let lua_json = state
             .load(include_str!("../../resources/lua/json.lua"))

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -24,6 +24,7 @@ mod script;
 mod servers;
 mod settings;
 mod socket;
+mod spellcheck;
 mod store;
 mod timer;
 mod tts;

--- a/src/lua/spellcheck.rs
+++ b/src/lua/spellcheck.rs
@@ -1,0 +1,163 @@
+use anyhow::{anyhow, Result};
+use hunspell_rs::{CheckResult, Hunspell};
+use mlua::prelude::LuaError;
+use mlua::{AnyUserData, Result as LuaResult, String as LuaString, Table, UserData};
+use std::sync::Arc;
+
+pub const LUA_GLOBAL_NAME: &str = "spellcheck";
+
+pub struct Spellchecker {
+    hunspell: Option<HunspellSafe>,
+}
+
+impl Spellchecker {
+    pub fn new() -> Self {
+        Spellchecker { hunspell: None }
+    }
+
+    pub fn init(&mut self, aff_path: &str, dict_path: &str) {
+        self.hunspell
+            .replace(HunspellSafe::from(Hunspell::new(aff_path, dict_path)));
+    }
+
+    fn check_initialized(&self) -> Result<()> {
+        match self.hunspell.is_none() {
+            true => Err(anyhow!("spellchecker not initialized")),
+            false => Ok(()),
+        }
+    }
+
+    pub fn check(&self, word: &str) -> Result<bool> {
+        self.check_initialized()?;
+        match self.hunspell.as_ref().unwrap().check(word) {
+            CheckResult::MissingInDictionary => Ok(false),
+            _ => Ok(true),
+        }
+    }
+
+    pub fn suggest(&self, word: &str) -> Result<Vec<String>> {
+        self.check_initialized()?;
+        Ok(self.hunspell.as_ref().unwrap().suggest(word))
+    }
+}
+
+impl UserData for Spellchecker {
+    fn add_methods<'lua, M: mlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
+        methods.add_function(
+            "init",
+            |ctx, (aff_path, dict_path): (LuaString, LuaString)| -> LuaResult<()> {
+                let this_aux = ctx.globals().get::<_, AnyUserData>(LUA_GLOBAL_NAME)?;
+                let mut this = this_aux
+                    .borrow_mut::<Spellchecker>()
+                    .map_err(LuaError::external)?;
+                this.init(aff_path.to_str()?, dict_path.to_str()?);
+                Ok(())
+            },
+        );
+        methods.add_function("check", |ctx, word: LuaString| -> LuaResult<bool> {
+            let this_aux = ctx.globals().get::<_, AnyUserData>(LUA_GLOBAL_NAME)?;
+            let this = this_aux
+                .borrow::<Spellchecker>()
+                .map_err(LuaError::external)?;
+            let found = this.check(word.to_str()?).map_err(LuaError::external)?;
+            Ok(found)
+        });
+        methods.add_function("suggest", |ctx, word: LuaString| -> LuaResult<Table> {
+            let this_aux = ctx.globals().get::<_, AnyUserData>(LUA_GLOBAL_NAME)?;
+            let this = this_aux
+                .borrow::<Spellchecker>()
+                .map_err(LuaError::external)?;
+            let res_table = ctx.create_table()?;
+            this.suggest(word.to_str()?)
+                .map_err(LuaError::external)?
+                .iter()
+                .enumerate()
+                .for_each(|(i, v)| res_table.set(i, v.as_str()).unwrap());
+            Ok(res_table)
+        });
+    }
+}
+
+#[derive(Clone)]
+struct HunspellSafe(Arc<Hunspell>);
+
+unsafe impl Send for HunspellSafe {}
+
+impl std::ops::Deref for HunspellSafe {
+    type Target = Hunspell;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Hunspell> for HunspellSafe {
+    fn from(hunspell: Hunspell) -> Self {
+        Self(Arc::new(hunspell))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::lua::spellcheck::{Spellchecker, LUA_GLOBAL_NAME};
+    use mlua::{Lua, Table};
+
+    const AFF_PATH: &str = "tests/spellcheck/tiny.aff";
+    const DICT_PATH: &str = "tests/spellcheck/tiny.dic";
+
+    #[test]
+    fn test_check_initialized() {
+        let mut spellchecker = Spellchecker::new();
+        assert_eq!(spellchecker.check_initialized().is_err(), true);
+        spellchecker.init(AFF_PATH, DICT_PATH);
+        assert_eq!(spellchecker.check_initialized().is_ok(), true);
+    }
+
+    #[test]
+    fn test_check() {
+        let mut spellchecker = Spellchecker::new();
+        assert_eq!(spellchecker.check("not-initialized").is_err(), true);
+        spellchecker.init(AFF_PATH, DICT_PATH);
+        assert_eq!(spellchecker.check("cromulent").unwrap(), false);
+        assert_eq!(spellchecker.check("cats").unwrap(), true);
+    }
+
+    #[test]
+    fn test_suggest() {
+        let mut spellchecker = Spellchecker::new();
+        assert_eq!(spellchecker.suggest("not-initialized").is_err(), true);
+        spellchecker.init(AFF_PATH, DICT_PATH);
+        let results = spellchecker.suggest("progra");
+        assert_eq!(results.unwrap(), vec!["program"])
+    }
+
+    #[test]
+    fn test_lua_api() {
+        let lua = Lua::new();
+        lua.globals()
+            .set(LUA_GLOBAL_NAME, Spellchecker::new())
+            .unwrap();
+
+        // Trying to use check before init should err.
+        let check_script = r#"check_res = spellcheck.check("cat")"#;
+        let no_init_check = lua.load(check_script).exec();
+        assert_eq!(no_init_check.is_err(), true);
+
+        // Trying to use suggest before init should err.
+        let suggest_script = r#"suggest_res = spellcheck.suggest("progra")"#;
+        let no_init_suggest = lua.load(suggest_script).exec();
+        assert_eq!(no_init_suggest.is_err(), true);
+
+        // We should be able to init without err.
+        let init_script = format!("spellcheck.init({:?}, {:?})", AFF_PATH, DICT_PATH);
+        lua.load(init_script.as_str()).exec().unwrap();
+
+        // After init we should be able to check/suggest.
+        lua.load(check_script).exec().unwrap();
+        let check_res: bool = lua.globals().get("check_res").unwrap();
+        assert_eq!(check_res, true);
+
+        lua.load(suggest_script).exec().unwrap();
+        let suggest_res: Table = lua.globals().get("suggest_res").unwrap();
+        assert_eq!(suggest_res.get::<i32, String>(0).unwrap(), "program");
+    }
+}

--- a/src/ui/help_handler.rs
+++ b/src/ui/help_handler.rs
@@ -197,6 +197,7 @@ fn load_files() -> HashMap<&'static str, &'static str> {
         "alias" => "lua_aliases.md",
         "config" => "lua_settings.md",
         "script" => "script.md",
+        "spellcheck" => "spellcheck.md",
         "trigger" => "lua_trigger.md",
         "timers" => "lua_timers.md",
         "gmcp" => "lua_gmcp.md",

--- a/tests/spellcheck/README.md
+++ b/tests/spellcheck/README.md
@@ -1,0 +1,4 @@
+# Spellcheck Dictionary Fixtures
+
+Graciously borrowed from https://github.com/drahnr/hunspell-rs/tree/master/tests/fixtures to allow
+testing the Blightmud spellcheck module without carrying around large Hunspell dictionary resources.

--- a/tests/spellcheck/tiny.aff
+++ b/tests/spellcheck/tiny.aff
@@ -1,0 +1,4 @@
+SET UTF-8
+
+SFX S Y 1
+SFX S   0     s          [^sxzhy]

--- a/tests/spellcheck/tiny.dic
+++ b/tests/spellcheck/tiny.dic
@@ -1,0 +1,3 @@
+2
+cat/S
+program/S


### PR DESCRIPTION
#### Description

This branch adds a new Lua module, `spellcheck`, with three functions:

* `spellcheck.init(aff_path, dict_path)` - initializes a spellchecker with the paths to a [Hunspell][0] compatible affix file and dictionary file. Must be called before any other spellcheck functions or an error will be thrown.
* `spellcheck.check(word) -> bool` - returns true if the word is in the dictionary that the spellchecker was initialized with. Errs if the spellchecker hasn't been initialized.
* `spellcheck.suggest(word) -> table` - if the given word is misspelled, returns a table array of suggested replacements in order of likelihood.

Presently these features are implemented with a backend that relies on the [`hunspell-rs` crate][1], which in turn uses [`hunspell-sys`][2] to interact with [libhunspell][0]. Hunspell is used extensively (e.g. by LibreOffice, Firefox) so compatible dictionaries/affix files are easy to source and the results are competitive with popular software. To avoid adding a new external dependency we use the "bundled" feature of `hunspell-sys` to have that crate bring along its own statically linked libhunspell. This means no changes are required for CI or the release process.

In the future the [`zspell`][3] crate looks like a promising pure Rust alternative to `hunspell-rs` that supports the Hunspell format and API. I elected not to use that crate for the short term because it doesn't yet have a stable API for providing suggestions and that's a core feature for a spellchecker. It should be possible to switch to this crate transparent to end users once it's feature complete.

For an example interactive spellchecker plugin built with this new Lua module, see [Blightspell][4].

Resolves #724.

[0]: http://hunspell.github.io/
[1]: https://crates.io/crates/hunspell-rs
[2]: https://crates.io/crates/hunspell-sys
[3]: https://crates.io/crates/zspell
[4]: https://github.com/cpu/blightspell

#### Demo

Here's a quick recorded demo of Blightspell in action:

[![asciicast](https://asciinema.org/a/ZvMTNWBIOk1ib84isRUxrUHBu.svg)](https://asciinema.org/a/ZvMTNWBIOk1ib84isRUxrUHBu)
