### PR TITLE
prompt masking bug fixes, tidying.

### DIFF
--- a/resources/help/scripting.md
+++ b/resources/help/scripting.md
@@ -37,6 +37,7 @@ by typing `/help <module>`.
 - `audio`       Functions to handle audio
 - `history`     Module that handles command history
 - `prompt`      Module for interacting with the prompt and it's content
+- `prompt_mask` Module for masking/decorating input prompt content.
 - `servers`     Server storage and handling
 - `fs`          Filesystem monitoring
 - `ttype`       TTYPE negotiation configuration

--- a/resources/lua/bindings.lua
+++ b/resources/lua/bindings.lua
@@ -16,8 +16,6 @@ bind("ctrl-d", "delete_right")
 bind("ctrl-h", "delete")
 bind("ctrl-k", "delete_to_end")
 bind("ctrl-u", "delete_from_start")
-bind("ctrl-k", "delete_to_end")
-bind("ctrl-u", "delete_from_start")
 
 -- ctrl + up/down
 blight.bind("\x1b[1;5a", function () search.find_up() end)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,7 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
             | Event::AddTag(_)
             | Event::ClearTags
             | Event::UserInputBuffer(_, _)
+            | Event::UserInputCursor(_)
             | Event::SetPromptMask(_)
             | Event::ClearPromptMask => {
                 //tts_ctrl.handle_events(event.clone());

--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -1443,11 +1443,10 @@ mod lua_script_tests {
     #[test]
     fn set_prompt_mask_content() {
         let (mut lua, _reader) = get_lua();
-
-        let mut mask_map = BTreeMap::new();
-        mask_map.insert(10, "hi".to_string());
-        mask_map.insert(20, "bye".to_string());
-        let mask = PromptMask::from(mask_map);
+        let mask = PromptMask::from(BTreeMap::from([
+            (10, "hi".to_string()),
+            (20, "bye".to_string()),
+        ]));
 
         lua.set_prompt_mask_content(&mask);
         lua.state.load("mask = prompt_mask.get()").exec().unwrap();


### PR DESCRIPTION
This branch is a follow up to https://github.com/Blightmud/Blightmud/pull/729 and may be easiest to review commit-wise since I've separated the changes by commit.

#### fix: address cursor regression, masking bugs. - 9bf7fa8aff40bc68ac19c473e29c816520edc43b
The code that was added for prompt masking in https://github.com/Blightmud/Blightmud/pull/729 had a few flaws that went missed (my bad :sweat:):

* Moving where the `UserInputBuffer` event was produced in the command input thread processing caused a regression where bindings that moved the cursor wouldn't redraw the prompt showing the new position.
* Using a binding that deleted content from the input prompt buffer could cause a deadlock where the binding handling code has a lock on the lua script, but the prompt mask clear function was trying to acquire the same lock to update the prompt content mask in the named registry value.
* I also noticed there was a pre-existing bug where bindings that deleted prompt buffer content didn't update the prompt content named registry value.

I've fixed all three bugs in this commit with two main changes:

1. The logic for deciding whether to emit a `UserInputBuffer` event now considers whether the buffer content changed, and only emits the event if it has. We also take care to update the mask and prompt content registry values here since we know there's been a change that requires it. This also allows removing the attempt to acquire the lua script lock from the `clear_mask()` function - we should have been handling that in the two call-sites that have their own lock and not conflated responsibilities in the command buffer.
2. If the buffer hasn't changed, but the prompt location has, we emit a new purpose specific event that indicates the UI should redraw the prompt. We don't invalidate the mask content since the buffer hasn't changed. This allows cursor movement to be updated immediately but without interfering with the masked display since it's still accurate to the content. I think this will also help implement https://github.com/Blightmud/Blightmud/issues/737 later on.

#### docs: add prompt_mask to scripting help - 059e67760c5c2fba3bab1a26647a39a926aa9a9d

Does what it says on the tin. `/help scripting` didn't include a mention of `prompt_mask` prior to this commit.

#### chore: tidy prompt mask impl/tests. - 54332ef0a6d58a4071256cf0e21bbd8ab9c645d0

There were a handful of places where relying more heavily on the iterator and from traits allows for cleaner code. As I'm getting better at writing Rust my old code looks worse :sweat_smile: 

#### tidy: remove duplicate bindings - 80a17b7797b6be16bec01a82e7c5c11025ca0b21

The bindings for `delete_to_end` and `delete_from_start` were duplicated in `bindings.lua`. This commit removes the duplicates.