### PR TITLE
fix: avoid panic from fast multi-line input.

### DIFF
--- a/src/model/prompt_mask.rs
+++ b/src/model/prompt_mask.rs
@@ -23,6 +23,9 @@ impl PromptMask {
         let mut offset = 0;
         for (idx, mask) in self.iter() {
             let adjusted_idx = offset + *idx as usize;
+            if adjusted_idx > masked_buf.len() {
+                return masked_buf.iter().collect();
+            }
             masked_buf.splice(adjusted_idx..adjusted_idx, mask.chars());
             offset += mask.len();
         }
@@ -135,6 +138,13 @@ mod test_prompt_mask {
         ]));
 
         let res = mask.mask_buffer(&buf);
-        assert_eq!(res, "this is *important*, ok")
+        assert_eq!(res, "this is *important*, ok");
+
+        let invalid_mask = PromptMask::from(BTreeMap::from([
+            (8, "*".to_string()),
+            (800, "!".to_string()),
+        ]));
+        let res = invalid_mask.mask_buffer(&buf);
+        assert_eq!(res, "this is *important, ok");
     }
 }


### PR DESCRIPTION
Pasting a buffer that contained multiple newlines is causing the prompt mask state and the input buffer to get out of sync, leading to an out of bounds panic trying to splice mask content into an empty string.

I'll investigate the desync further but in the meantime the masking code should be resilient and not panic. This commit adds bounds checking to the masking process and updates the unit tests to include this case. After applying this fix I'm no longer able to panic the client with blightspell loaded.