### PR TITLE
Prevent Event::SetPromptMask from interupting ctrl-c

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,8 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
                     | Event::UserInputBuffer(..)
                     | Event::TimedEvent(..)
                     | Event::TimerTick(..)
+                    | Event::SetPromptMask(..)
+                    | Event::ClearPromptMask
             );
         }
 


### PR DESCRIPTION
The `ctrl-c` cycle (needing to submit it twice) is sensitive to other events arriving between the first and second `ctrl-c` (sigint) signal. The new event SetPromptMask was not included in the whitelist of events that can be received and would interupt the ctrl-c sequence.

This system should probably be re-worked to use some form of timer or at least highlight that the sequence has been interrupted. It's otherwise quite easy for a plugin to unknowingly interrupt this cycle.