### PR TITLE
Fixes the scroll split sizing when top bar is hidden

### DIFF
--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -625,7 +625,7 @@ impl SplitScreen {
             write!(
                 self.screen,
                 "{}{}{:━<4$}{}",
-                cursor::Goto(1, scroll_range + 2),
+                cursor::Goto(1, scroll_range + self.output_start_line),
                 color::Fg(color::Green),
                 "━ (scroll) ",
                 color::Fg(color::Reset),


### PR DESCRIPTION
Fixes: #752
