### PR TITLE
Allows setting status area height to 0

### DIFF
--- a/resources/help/lua_status_area.md
+++ b/resources/help/lua_status_area.md
@@ -6,9 +6,10 @@ These methods allow you to control the height and content in the status area.
 
 ***blight.status_height([height]) -> int***
 Set or get the status area height. The first and last row will always be
-rendered as bars. But you can still print to these bars
+rendered as bars. But you can still print to these bars. Setting the height to
+0 will hide the status area.
 
-- `height`  The height to set (1 <= height <= 5) *Optional*
+- `height`  The height to set (0 <= height <= 5) *Optional*
 - Returns the current status area height
 
 ***blight.status_line(index, line)***

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -107,6 +107,7 @@ impl UserData for Blight {
         });
         methods.add_function("status_height", |ctx, requested: Option<u16>| {
             let height: u16 = if let Some(height) = requested {
+                let height = height.clamp(0, 5);
                 let this_aux = ctx.globals().get::<_, AnyUserData>("blight")?;
                 let this = this_aux.borrow::<Blight>()?;
                 this.main_writer


### PR DESCRIPTION
It hasn't been possible to completely hide the status area previously.
This change allows one to call `blight.status_height(0)` which makes the
status area not render.

Fixes: #751
