### PR TITLE
net: rewrite version check using reqwest.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,6 @@ version = "5.2.0"
 dependencies = [
  "anyhow",
  "chrono",
- "curl",
  "env_logger",
  "flate2",
  "getopts",
@@ -256,10 +255,11 @@ dependencies = [
  "notify-debouncer-mini",
  "pulldown-cmark",
  "regex",
+ "reqwest",
  "rodio",
  "ron",
  "rs-complete",
- "rustls",
+ "rustls 0.21.0",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -271,7 +271,7 @@ dependencies = [
  "timer",
  "tts",
  "vte 0.11.0",
- "webpki-roots",
+ "webpki-roots 0.23.0",
 ]
 
 [[package]]
@@ -643,36 +643,6 @@ name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
-
-[[package]]
-name = "curl"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "winapi",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.60+curl-7.88.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "717abe2cb465a5da6ce06617388a3980c9a2844196734bec8ccb8e575250f13f"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "winapi",
-]
 
 [[package]]
 name = "cxx"
@@ -1276,6 +1246,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.20.8",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2185,11 +2168,10 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.83"
+version = "0.9.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
+checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -2522,9 +2504,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "async-compression",
  "base64 0.21.0",
@@ -2536,6 +2518,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
@@ -2543,16 +2526,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.20.8",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -2678,6 +2665,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
@@ -2742,15 +2741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
-dependencies = [
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3308,6 +3298,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.8",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3744,6 +3745,25 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ anyhow = "1.0.70"
 lazy_static = "1.4.0"
 rs-complete = "1.3.1"
 getopts = "0.2.21"
-curl = "0.4.44"
 human-panic = "1.1.1"
 tts = { version = "0.25.5", optional = true }
 serde_json = "1.0.95"
@@ -46,8 +45,9 @@ rodio = "0.17.0"
 notify-debouncer-mini = "0.2.1"
 hunspell-rs = "0.4.0"
 hunspell-sys = { version = "0.3.0", features = ['bundled'] }
-rustls = { version = "0.21.0", features = ['dangerous_configuration']}
+rustls = { version = "0.21.0", features = ['dangerous_configuration'] }
 webpki-roots = { version = "0.23.0" }
+reqwest = { version = "0.11.16", default-features = false, features = ['rustls-tls', 'json'] }
 
 [dev-dependencies]
 mockall = "0.11.4"


### PR DESCRIPTION
Previously the `net/check_version.rs` implementation used to warn users at runtime about newly released Blightmud versions relied on Rust bindings for the native `curl` library. This was the only place in the codebase using that dependency.

Instead of relying on a crate based on native code, this commit replaces the implementation with [`reqwest`](https://docs.rs/reqwest/latest/reqwest/) using the `rustls` TLS backend we implemented for MUD TLS. Using reqwest w/ rustls provides end-to-end HTTP(S) requests in pure Rust without needing `libcurl` or `libssl`.

Since we're performing version checks in a background thread I've implemented this check using the blocking reqwest client.

Along the way I made some refactoring cleanups:

* `diff_version` isn't required, we can use `&str.cmp` directly.
* `Fetcher`'s error `Result` was never meaningfully used, so switch to `Option`.
* Rather than returning `Vec<u8>` and manually deserializing fields, the `Fetcher` trait is switched to return a struct with a derived `Deserialize` and the impl uses reqwest's `Response.json` to unmarshal the HTTP response into it.