### PR TITLE
tests: restore ignored tests.

### DIFF
--- a/tests/communication_tests.rs
+++ b/tests/communication_tests.rs
@@ -7,7 +7,6 @@ use libtelnet_rs::telnet::{op_command::*, op_option::*};
 mod common;
 
 #[test]
-#[ignore]
 fn test_ttype_negotiation() -> std::io::Result<()> {
     let (mut connection, handle) = setup();
 
@@ -46,7 +45,6 @@ fn test_ttype_negotiation() -> std::io::Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_gmcp_negotiation() -> std::io::Result<()> {
     let (mut connection, handle) = setup();
 

--- a/tests/connection_tests.rs
+++ b/tests/connection_tests.rs
@@ -4,7 +4,6 @@ use common::{join_blightmud, Server};
 mod common;
 
 #[test]
-#[ignore]
 fn test_connect() {
     let mut server = Server::bind(0);
 
@@ -25,7 +24,6 @@ fn test_connect() {
 }
 
 #[test]
-#[ignore]
 fn test_connect_world() {
     let mut server = Server::bind(0);
 
@@ -53,7 +51,6 @@ fn test_connect_world() {
 }
 
 #[test]
-#[ignore]
 fn test_reconnect_world() {
     let server = Server::bind(0);
 
@@ -66,7 +63,6 @@ fn test_reconnect_world() {
 }
 
 #[test]
-#[ignore]
 fn test_is_connected() {
     let server = Server::bind(0);
 


### PR DESCRIPTION
Now that the version checking thread run at application startup doesn't have unsound native behaviour that can cause flakyness we can restore the unit tests that invoke `common::start_blightmud`.