### PR TITLE
Makes TTYPE script check if tts.is_available()

### DIFF
--- a/resources/lua/ttype.lua
+++ b/resources/lua/ttype.lua
@@ -35,7 +35,7 @@ local reader_mode = false
 local function init()
     index = 1
     if auto_reader_mode then
-        if tts.is_enabled() or blight.is_reader_mode() then
+        if (tts.is_available() and tts.is_enabled()) or blight.is_reader_mode() then
             mtts = mtts | mod.MTTS_SCREEN_READER
         else
             mtts = mtts & ~mod.MTTS_SCREEN_READER


### PR DESCRIPTION
The TTYPE script would generate a "Not compiled with TTS" warning when
connecting to a mud that supports TTS. This was because
`tts.is_available()` wasn't checked before calling other tts functions.

Fixes: #786
