### PR TITLE
Fixes concurrency issue in integration tests

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -21,12 +21,12 @@ pub fn join_blightmud(handle: JoinHandle<Result<()>>) {
 }
 
 #[allow(dead_code)]
-pub fn setup() -> (Connection, JoinHandle<Result<()>>) {
+pub fn setup(script_file: Option<String>) -> (Connection, JoinHandle<Result<()>>) {
     let mut server = Server::bind(0);
 
     let mut rt = RuntimeConfig::default();
     rt.headless_mode = true;
-    rt.script = Some("tests/timer_test.lua".to_string());
+    rt.script = script_file;
     rt.eval = Some(include_str!("quit_on_disconnect.lua").to_string());
     rt.integration_test = true;
     println!("Test server running at: {}", server.local_addr);

--- a/tests/communication_tests.rs
+++ b/tests/communication_tests.rs
@@ -8,7 +8,7 @@ mod common;
 
 #[test]
 fn test_ttype_negotiation() -> std::io::Result<()> {
-    let (mut connection, handle) = setup();
+    let (mut connection, handle) = setup(None);
 
     connection.send(&[IAC, WILL, TTYPE]);
     assert_eq!(connection.read(3), &[IAC, DO, TTYPE]);
@@ -46,7 +46,7 @@ fn test_ttype_negotiation() -> std::io::Result<()> {
 
 #[test]
 fn test_gmcp_negotiation() -> std::io::Result<()> {
-    let (mut connection, handle) = setup();
+    let (mut connection, handle) = setup(None);
 
     connection.send(&[IAC, WILL, GMCP]);
     assert_eq!(connection.read(3), &[IAC, DO, GMCP]);

--- a/tests/timer_tests.rs
+++ b/tests/timer_tests.rs
@@ -5,7 +5,7 @@ mod common;
 
 #[test]
 fn timer_test() {
-    let (mut connection, handle) = setup();
+    let (mut connection, handle) = setup(Some("tests/timer_test.lua".to_string()));
 
     assert_eq!(connection.read(2), &[IAC, NOP]);
     assert_eq!(connection.read(2), &[IAC, NOP]);


### PR DESCRIPTION
The `setup()` function used to prepare a local blightmud instance when running integration tests would always load the script `tests/timer_test.lua`. This script sends some data over the wire which could in some cases interupt other telnet negotiation tests. This should no longer be the case now.