### PR TITLE
feature: make spellcheck dependency optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ doctest = false
 crate-type = ["rlib"]
 
 [features]
+default = ["spellcheck"]
 text-to-speech = ["tts"]
+spellcheck = ["hunspell-rs", "hunspell-sys"]
 
 [dependencies]
 libtelnet-rs = "2.0.0"
@@ -43,8 +45,8 @@ serde_json = "1.0.96"
 git2 = "0.17.1"
 rodio = "0.17.0"
 notify-debouncer-mini = "0.2.1"
-hunspell-rs = "0.4.0"
-hunspell-sys = { version = "0.3.0", features = ['bundled'] }
+hunspell-rs = { version = "0.4.0", optional = true }
+hunspell-sys = { version = "0.3.0", features = ['bundled'], optional = true }
 rustls = { version = "0.21.0", features = ['dangerous_configuration'] }
 webpki-roots = { version = "0.23.0" }
 reqwest = { version = "0.11.16", default-features = false, features = ['rustls-tls', 'json'] }

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ commands that might fit your system:
 - Ubuntu    `apt install libclang-dev libspeechd-dev speech-dispatcher speech-dispatcher-espeak espeak`
 - Arch      `pacman -S speech-dispatcher espeak`
 
+### Compile without spellchecking
+
+Some users may encounter issues building the spellcheck feature on MacOS ARM64 (M1/M2). To
+build Blightmud without the spellcheck feature, use `--no-default-features`. E.g.:
+
+- Install rust
+- Run `cargo build --no-default-features` or `cargo build --no-default-features --features text-to-speech`
+- Run `cargo run --no-default-features` or `cargo run --no-default-features --features text-to-speech` to run
+
 ## Installation
 
 - **Ubuntu/Debian**      : Deb packages can be found on the releases page

--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -10,8 +10,8 @@ use super::{
 use crate::lua::fs::Fs;
 use crate::lua::prompt::Prompt;
 use crate::lua::prompt_mask::PromptMask;
-use crate::lua::spellcheck;
-use crate::lua::spellcheck::Spellchecker;
+#[cfg(feature = "spellcheck")]
+use crate::lua::spellcheck::{self, Spellchecker};
 use crate::model::Completions;
 use crate::tools::util::expand_tilde;
 use crate::{event::Event, lua::servers::Servers, model, model::Line};
@@ -162,6 +162,7 @@ fn create_default_lua_state(builder: LuaScriptBuilder, store: Option<Store>) -> 
         globals.set("servers", Servers {})?;
         globals.set("prompt", Prompt {})?;
         globals.set("prompt_mask", PromptMask {})?;
+        #[cfg(feature = "spellcheck")]
         globals.set(spellcheck::LUA_GLOBAL_NAME, Spellchecker::new())?;
 
         lua_global_resources!(

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -24,6 +24,7 @@ mod script;
 mod servers;
 mod settings;
 mod socket;
+#[cfg(feature = "spellcheck")]
 mod spellcheck;
 mod store;
 mod timer;


### PR DESCRIPTION
This commit adds a `spellcheck` feature flag that is default-enabled, and makes the `hunspell-rs` and `hunspell-sys` dependencies optional based on that feature flag.

This will allow most users to get spellchecking by default, but for the select few having trouble building `hunspell-sys` on ARM64, they can use `--no-default-features` to avoid the problem.

It might also be worth adding CI coverage for build/test with `--no-default-features` but CI time is getting quite long with the recent additions so for now I've left it out.