### PR TITLE
feat: add echo_input setting.

### DIFF
--- a/resources/help/scrolling.md
+++ b/resources/help/scrolling.md
@@ -3,6 +3,10 @@
 You can scroll the output history of your game using keys (default
 `PgUp`/`PgDn`) or mouse (if you enabled the setting).
 
+You can scroll through commands you sent to the game using
+`Ctrl PgUp`/`Ctrl PgDown` if `/set echo_input on` is enabled (default). 
+See `/help search` for more information.
+
 If your current output area is longer then 20 lines then blightmud will split
 the window into two, the upper will show you the output history that you are
 scrolling and the lower will show you the live output from your mud.

--- a/resources/help/search.md
+++ b/resources/help/search.md
@@ -28,11 +28,15 @@ call.
 Searches upwards from current position for the previous occurence of an input
 string. Eg. `> your input`.
 
+**Note:** Requires `/set echo_input on`.
+
 ##
 
 ***search.find_next_input()***
 Searches downwards from current position for the next occurence of an input
 string. Eg. `> your input`.
+
+**Note:** Requires `/set echo_input on`.
 
 ##
 
@@ -45,4 +49,4 @@ Blightmud will do it's best to attempt to hilite matches. However this can
 disrupt mud color coding while searching or be disrupted by mud color encoding.
 
 Stepping through output lines can in some cases match mud output if your mud
-outputs similar lines.
+outputs similar lines. Requires `/set echo_input on`.

--- a/resources/help/settings.md
+++ b/resources/help/settings.md
@@ -24,6 +24,7 @@ Available settings are:
 - `tts_enabled`         Enable tts (only if compiled with TTS)
 - `reader_mode`         Switches to a screen reader friendly TUI. (Does not support `status area`.)
 - `hide_topbar`         Toggles the topbar
+- `echo_input`          Toggles whether user input is echoed on-screen with a `> ` prefix.
 
 ##
 

--- a/resources/lua/search.lua
+++ b/resources/lua/search.lua
@@ -20,12 +20,25 @@ function mod.find_down()
     end
 end
 
+local function echo_input_enabled()
+    if settings.get("echo_input") then
+        return true
+    end
+
+    blight.output(C_RED .. "[!!] You must enable echo_input with '/set echo_input on' to find by input." .. C_RESET)
+    return false
+end
+
 function mod.find_last_input()
-    blight.find_backward(input_pattern)
+    if echo_input_enabled() then
+        blight.find_backward(input_pattern)
+    end
 end
 
 function mod.find_next_input()
-    blight.find_forward(input_pattern)
+    if echo_input_enabled() then
+        blight.find_forward(input_pattern)
+    end
 end
 
 return mod

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use libtelnet_rs::bytes::Bytes;
 use libtelnet_rs::events::TelnetEvents;
 use log::{error, info};
 use std::path::PathBuf;
+use std::sync::atomic::Ordering;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::{env, fs, thread, time};
 pub use tools::register_panic_hook;
@@ -24,7 +25,7 @@ mod ui;
 
 use crate::event::{spawn_quit_confirm_timeout_thread, Event, QuitMethod};
 use crate::io::{FSMonitor, SaveData};
-use crate::model::{Servers, HIDE_TOPBAR, READER_MODE, SCROLL_SPLIT};
+use crate::model::{Servers, ECHO_INPUT, HIDE_TOPBAR, READER_MODE, SCROLL_SPLIT};
 use crate::session::{Session, SessionBuilder};
 use crate::timer::{spawn_timer_thread, TimerEvent};
 use crate::tools::patch::migrate_v2_settings_and_servers;
@@ -192,6 +193,7 @@ pub fn start(rt: RuntimeConfig) -> Result<()> {
         .reader_mode(reader_mode)
         .headless(rt.headless_mode)
         .save_history(settings.get(SAVE_HISTORY).unwrap())
+        .echo_input(settings.get(ECHO_INPUT).unwrap())
         .build();
 
     if let Err(error) = run(main_thread_read, session, rt) {
@@ -384,6 +386,7 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
                 HIDE_TOPBAR | SCROLL_SPLIT => {
                     screen.setup()?;
                 }
+                ECHO_INPUT => session.echo_input.store(value, Ordering::Relaxed),
                 _ => {}
             },
             Event::StartLogging(world, force) => {

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -21,7 +21,8 @@ pub const READER_MODE: &str = "reader_mode";
 pub const HIDE_TOPBAR: &str = "hide_topbar";
 pub const COMMAND_SEARCH: &str = "command_search";
 pub const SMART_HISTORY: &str = "smart_history";
-pub const SETTINGS: [&str; 11] = [
+pub const ECHO_INPUT: &str = "echo_input";
+pub const SETTINGS: [&str; 12] = [
     LOGGING_ENABLED,
     TTS_ENABLED,
     MOUSE_ENABLED,
@@ -33,6 +34,7 @@ pub const SETTINGS: [&str; 11] = [
     HIDE_TOPBAR,
     COMMAND_SEARCH,
     SMART_HISTORY,
+    ECHO_INPUT,
 ];
 
 impl Settings {
@@ -68,6 +70,7 @@ impl Default for Settings {
         settings.insert(HIDE_TOPBAR.to_string(), false);
         settings.insert(COMMAND_SEARCH.to_string(), false);
         settings.insert(SMART_HISTORY.to_string(), false);
+        settings.insert(ECHO_INPUT.to_string(), true);
         Self { settings }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -34,6 +34,7 @@ pub struct Session {
     pub logger: Arc<Mutex<dyn LogWriter + Send>>,
     pub tts_ctrl: Arc<Mutex<TTSController>>,
     pub command_buffer: Arc<Mutex<CommandBuffer>>,
+    pub echo_input: Arc<AtomicBool>,
 }
 
 #[cfg_attr(test, automock)]
@@ -172,6 +173,7 @@ pub struct SessionBuilder {
     reader_mode: bool,
     save_history: bool,
     headless: bool,
+    echo_input: bool,
 }
 
 impl SessionBuilder {
@@ -184,6 +186,7 @@ impl SessionBuilder {
             reader_mode: false,
             save_history: false,
             headless: false,
+            echo_input: true,
         }
     }
 
@@ -222,6 +225,11 @@ impl SessionBuilder {
         self
     }
 
+    pub fn echo_input(mut self, echo_input: bool) -> Self {
+        self.echo_input = echo_input;
+        self
+    }
+
     pub fn build(self) -> Session {
         let main_writer = self.main_writer.unwrap();
         let timer_writer = self.timer_writer.unwrap();
@@ -231,6 +239,7 @@ impl SessionBuilder {
         let reader_mode = self.reader_mode;
         let headless = self.headless;
         let tts_ctrl = Arc::new(Mutex::new(TTSController::new(tts_enabled, headless)));
+        let echo_input = self.echo_input;
 
         let lua_builder = LuaScriptBuilder::new(main_writer.clone())
             .dimensions(dimensions)
@@ -256,6 +265,7 @@ impl SessionBuilder {
             logger: Arc::new(Mutex::new(Logger::default())),
             tts_ctrl: tts_ctrl.clone(),
             command_buffer: Arc::new(Mutex::new(CommandBuffer::new(tts_ctrl, lua_script))),
+            echo_input: Arc::new(AtomicBool::new(echo_input)),
         }
     }
 }


### PR DESCRIPTION
Previously all `ServerInput` events unconditionally called `screen.print_send` to echo input sent by a user to the screen. In the split screen mode this results in the input appearing with a `> ` prefix and special colouring. That's a sensible default but I would be happy to rely on the input buffer history for remembering what I sent and save some output screen space by not echoing all my input.

This commit adds a `echo_input` setting that can be changed to disable screen input echo behaviour on an opt-in basis.

The setting defaults to true, and can be changed at runtime with immediate effect. When set to false input is still logged but will no longer appear on the screen with a `> ` prefix. Setting it to true will restore the echo effect.