### PR TITLE
deps: bump webpki-roots v0.24.0 -> v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
  "timer",
  "tts",
  "vte 0.11.1",
- "webpki-roots 0.24.0",
+ "webpki-roots 0.25.0",
 ]
 
 [[package]]
@@ -3116,12 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
-dependencies = [
- "rustls-webpki",
-]
+checksum = "1a4ac452058d835c2b7ff6d74f0ad9f40e172bb1ce661b1444f397eeb1d19e6d"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ notify-debouncer-mini = "0.3.0"
 hunspell-rs = { version = "0.4.0", optional = true }
 hunspell-sys = { version = "0.3.0", features = ['bundled'], optional = true }
 rustls = { version = "0.21.5", features = ['dangerous_configuration'] }
-webpki-roots = { version = "0.24.0" }
+webpki-roots = { version = "0.25.0" }
 reqwest = { version = "0.11.18", default-features = false, features = ['blocking', 'rustls-tls', 'json'] }
 
 [dev-dependencies]

--- a/src/net/tls.rs
+++ b/src/net/tls.rs
@@ -85,7 +85,7 @@ impl TlsStream {
 
     fn default_root_certs() -> RootCertStore {
         let mut root_store = RootCertStore::empty();
-        root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
             OwnedTrustAnchor::from_subject_spki_name_constraints(
                 ta.subject,
                 ta.spki,


### PR DESCRIPTION
This branch updates the rustls webpki-roots dependency from v0.24.0 to v0.25.0, addressing one breaking API change at the same time.

Replaces https://github.com/Blightmud/Blightmud/pull/851