### PR TITLE
Cargo: specify opt-level for hunspell-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,11 @@ mockall_double = "0.3.0"
 rustls-pemfile = "1.0.3"
 env_logger = "0.10.0"
 
+[profile.dev.package.hunspell-sys]
+# fixes debug profile build errs from warnings of the form:
+#   warning _FORTIFY_SOURCE requires compiling with optimization (-O)
+opt-level = 3
+
 [package.metadata.rpm]
 package = "blightmud"
 


### PR DESCRIPTION
The `hunspell-sys` crate builds native code that emits warnings when building with `--debug`. These warnings are treated as errors by cargo and so breaks blightmud builds that enable spellcheck unless `--release` is used.

This commit fixes `--debug` builds by explicitly setting optimizations enabled for the `hunspell-sys` dependency when using the `dev` profile. We don't need debug info for hunspell-sys and this fixes the build error.