### PR TITLE
project: add Nix Flake support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *.bak
 /scripts/blightmud-pkg
 /scripts/homebrew-blightmud
+/result
+/.direnv

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ me to the word **blight** and here we are.
 
 ![screenshot](resources/images/demo.gif)
 
+## Installation
+
+- **Ubuntu/Debian**      : Deb packages can be found on the releases page
+- **Archlinux/Manjaro**  : Packages are available on [AUR](https://aur.archlinux.org/packages/?O=0&K=blightmud)
+- **NixOS/Nix**          : Packages are available in [NixPkgs](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=blightmud), or from our [Flake](flake.nix)
+- **Mac/Homebrew**       : We have a homebrew tap `brew tap Blightmud/blightmud` (intel only, if you're on Apple Silicon (darwin) compiling is the best option)
+- **Cargo**              : If you have rust installed just run `cargo install --git https://github.com/blightmud/blightmud blightmud` from your favourite terminal.
+- **Other/Alternative**  : Download source and run `cargo install --path .` from the project root
+- **Windows**            : No native windows support but Blightmud runs fine under WSL
+
 ## Compiling
 
 - Install rust
@@ -108,16 +118,6 @@ have a ready-to-go and self-contained build environment:
 - Run `nix build .#blightmud-tts` to build Blightmud with text to speech.
 - Run `nix develop` to enter a dev. env. with Rust nightly.
 - Run `nix develop .#stable` to enter a dev. env. with the latest stable Rust.
-
-## Installation
-
-- **Ubuntu/Debian**      : Deb packages can be found on the releases page
-- **Archlinux/Manjaro**  : Packages are available on [AUR](https://aur.archlinux.org/packages/?O=0&K=blightmud)
-- **NixOS/Nix**          : Packages are available in [NixPkgs](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=blightmud), or from our [Flake](flake.nix)
-- **Mac/Homebrew**       : We have a homebrew tap `brew tap Blightmud/blightmud` (intel only, if you're on Apple Silicon (darwin) compiling is the best option)
-- **Cargo**              : If you have rust installed just run `cargo install --git https://github.com/blightmud/blightmud blightmud` from your favourite terminal.
-- **Other/Alternative**  : Download source and run `cargo install --path .` from the project root
-- **Windows**            : No native windows support but Blightmud runs fine under WSL
 
 ## Support, questions and help
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,27 @@ build Blightmud without the spellcheck feature, use `--no-default-features`. E.g
 - Run `cargo build --no-default-features` or `cargo build --no-default-features --features text-to-speech`
 - Run `cargo run --no-default-features` or `cargo run --no-default-features --features text-to-speech` to run
 
+### Nix
+
+If you're using [Nix](https://nixos.org/) or NixOS you can try Blightmud
+right away with:
+
+- `nix run github:blightmud/blightmud`
+
+For developers, once you've cloned this repo you can use the 
+[Blightmud flake](flake.nix) directly, or with [direnv](https://direnv.net/), to
+have a ready-to-go and self-contained build environment:
+
+- Run `nix build` to build Blightmud without text to speech.
+- Run `nix build .#blightmud-tts` to build Blightmud with text to speech.
+- Run `nix develop` to enter a dev. env. with Rust nightly.
+- Run `nix develop .#stable` to enter a dev. env. with the latest stable Rust.
+
 ## Installation
 
 - **Ubuntu/Debian**      : Deb packages can be found on the releases page
 - **Archlinux/Manjaro**  : Packages are available on [AUR](https://aur.archlinux.org/packages/?O=0&K=blightmud)
-- **NixOS/Nix**          : Packages are available in [NixPkgs](https://search.nixos.org/packages?channel=21.11&from=0&size=50&sort=relevance&type=packages&query=blightmud).
+- **NixOS/Nix**          : Packages are available in [NixPkgs](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=blightmud), or from our [Flake](flake.nix)
 - **Mac/Homebrew**       : We have a homebrew tap `brew tap Blightmud/blightmud` (intel only, if you're on Apple Silicon (darwin) compiling is the best option)
 - **Cargo**              : If you have rust installed just run `cargo install --git https://github.com/blightmud/blightmud blightmud` from your favourite terminal.
 - **Other/Alternative**  : Download source and run `cargo install --path .` from the project root

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,149 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1698318101,
+        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "systems": "systems_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1698458995,
+        "narHash": "sha256-nF8E8Ur5NggwPQNp3w/fddWmQrNEwCm0dgz6tk8Ew6E=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "571fee291b386dd6fe0d125bc20a7c7b3ad042ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
+      perSystem = { config, self', pkgs, lib, system, ... }:
+        let
+          cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+
+          runtimeDeps = with pkgs; [ alsa-lib openssl speechd ];
+          buildDeps = with pkgs; [ pkg-config rustPlatform.bindgenHook ];
+          devDeps = with pkgs; [ gdb asciinema ];
+
+          withFeatures = features: {
+            inherit (cargoToml.package) name version;
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+            buildFeatures = features;
+            nativeBuildInputs = buildDeps;
+            buildInputs = runtimeDeps;
+            doCheck = false; # Some tests require networking
+          };
+
+          mkDevShell = rustc:
+            pkgs.mkShell {
+              shellHook = ''
+                export RUST_SRC_PATH=${pkgs.rustPlatform.rustLibSrc}
+              '';
+              buildInputs = runtimeDeps;
+              nativeBuildInputs = buildDeps ++ devDeps ++ [ rustc ];
+            };
+        in {
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ (import inputs.rust-overlay) ];
+          };
+          packages.default = self'.packages.blightmud-tts;
+          devShells.default = self'.devShells.nightly;
+
+          # Blightmud w/ text to speech enabled.
+          packages.blightmud-tts =
+            pkgs.rustPlatform.buildRustPackage (withFeatures "tts");
+          # Blightmud w/o text to speech enabled.
+          packages.blightmud =
+            pkgs.rustPlatform.buildRustPackage (withFeatures "");
+
+          # Nightly Rust dev env
+          devShells.nightly = (mkDevShell (pkgs.rust-bin.selectLatestNightlyWith
+            (toolchain: toolchain.default)));
+          # Stable Rust dev env
+          devShells.stable = (mkDevShell pkgs.rust-bin.stable.latest.default);
+        };
+    };
+}


### PR DESCRIPTION
## Description

I expect that not many folks are using Nix, but I am and having this in-tree makes my life _way_ easier as a maintainer. I'd love to merge this to help both myself, and anyone else that's [Nix curious](https://zero-to-nix.com/). Note that you do _not_ need to install NixOS to use Nix on your existing operating system to manage build environments.

In the end, this change is ~3 new files (`Flake.nix`, `Flake.lock`, `.envrc`) in the repo that everyone else can ignore if they want to. If there are issues with the Nix setup, please direct them to me for fixes/maintenance. If I'm not around, feel free to back the changes out! Nothing gained nothing lost.

If there's anything I can do to make this more appealing to merge, let me know. I think there's value in this setup but I acknowledge not everyone is as keen on Nix. I would be open to adding CI coverage but for now it felt best to omit that.

## Details

This commit adds support for building Blightmud as [a Nix flake](https://zero-to-nix.com/concepts/flakes).

It also defines a reproducible development environment that can be activated on-demand, taking care of setting up native code deps (like OpenSSL, and ALSA components) and making available tools like clippy. By additionally adding a `.envrc` file in-repo, users of [direnv](https://direnv.net/) can have the Flake based dev environment automatically loaded/unloaded when entering/exiting the project directory in a shell.

Nix users can run Blightmud with no installation steps (including cloning the repo) with:

     nix run github:blightmud/blightmud

_Note: Until this is merged, you'll need to use `nix run github.com:cpu/blightmud/cb22bfe` instead_

Or, after cloning the repo and entering the directory:

  1. Build Blightmud without text-to-speech: 
  
```
     nix build && ./result/bin/blightmud
```

  2. Build Blightmud with text-to-speeech:

```  
     nix build .#blightmud-tts && ./result/bin/blightmud
```

  3. Activate a development environment with Rust nightly: 

```  
     nix develop
     cargo test
```

  4. Activate a development environment with Rust stable: 

```  
     nix develop .#stable 
     cargo test
```