### PR TITLE
net: configure TCP keepalive, prefer IPv6, more debug info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "simple-logging",
+ "socket2 0.5.5",
  "strip-ansi-escapes",
  "syntect",
  "termion",
@@ -1256,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libgit2-sys"
@@ -2483,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -2804,7 +2805,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.3",
+ "socket2 0.5.5",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ hunspell-sys = { version = "0.3.0", features = ['bundled'], optional = true }
 rustls = { version = "0.21.8", features = ['dangerous_configuration'] }
 webpki-roots = { version = "0.25.2" }
 reqwest = { version = "0.11.22", default-features = false, features = ['blocking', 'rustls-tls', 'json'] }
+socket2 = "0.5.5"
 
 [dev-dependencies]
 mockall = "0.11.4"

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -22,7 +22,10 @@ pub const HIDE_TOPBAR: &str = "hide_topbar";
 pub const COMMAND_SEARCH: &str = "command_search";
 pub const SMART_HISTORY: &str = "smart_history";
 pub const ECHO_INPUT: &str = "echo_input";
-pub const SETTINGS: [&str; 12] = [
+
+pub const KEEPALIVE_ENABLED: &str = "keepalive_enabled";
+
+pub const SETTINGS: [&str; 13] = [
     LOGGING_ENABLED,
     TTS_ENABLED,
     MOUSE_ENABLED,
@@ -35,6 +38,7 @@ pub const SETTINGS: [&str; 12] = [
     COMMAND_SEARCH,
     SMART_HISTORY,
     ECHO_INPUT,
+    KEEPALIVE_ENABLED,
 ];
 
 impl Settings {
@@ -71,6 +75,7 @@ impl Default for Settings {
         settings.insert(COMMAND_SEARCH.to_string(), false);
         settings.insert(SMART_HISTORY.to_string(), false);
         settings.insert(ECHO_INPUT.to_string(), true);
+        settings.insert(KEEPALIVE_ENABLED.to_string(), true);
         Self { settings }
     }
 }

--- a/src/net/util.rs
+++ b/src/net/util.rs
@@ -1,19 +1,140 @@
-use std::{
-    net::{TcpStream, ToSocketAddrs},
-    time::Duration,
-};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, Result};
+use log::debug;
+use socket2::{Socket, TcpKeepalive};
 
+use crate::io::SaveData;
+use crate::model::{self, KEEPALIVE_ENABLED};
+
+/// Connect to a remote host and port, returning a `TcpStream` if successful.
+///
+/// This function will resolve potential IP addresses for the given host/port combination and
+/// prefer connecting to an IPv6 address if available, falling back to IPv4 if necessary.
+///
+/// Unless disabled by setting the` KEEPALIVE_ENABLED` setting to false the streams returned
+/// by this function will have [TCP keepalive](https://en.wikipedia.org/wiki/Keepalive#TCP_keepalive)
+/// configured. This is important for Telnet connections since the protocol itself has no
+/// application layer keepalive.
 pub fn open_tcp_stream(host: &str, port: u16) -> Result<TcpStream> {
-    let mut addr_iter = (host, port).to_socket_addrs()?;
+    let sock = Socket::from(opportunistic_connect(prepare_addresses(host, port)?)?);
 
-    let timeout = Duration::new(3, 0);
-    let stream = addr_iter.find_map(|addr| TcpStream::connect_timeout(&addr, timeout).ok());
+    if model::Settings::try_load()?
+        .get(KEEPALIVE_ENABLED)
+        .unwrap_or(true)
+    {
+        debug!("enabling TCP keepalive");
+        // Values are loosely based on Mudlet's settings, but tuned to be a little more aggressive.
+        // E.g. a shorter wait before sending keepalives, a shorter wait between keepalives, and
+        // fewer retries before giving up.
+        // https://github.com/Mudlet/Mudlet/blob/31ea3079e63735a344379e714117e4f1ad6b2f1b/src/ctelnet.cpp#L3052-L3138
+        sock.set_tcp_keepalive(
+            &TcpKeepalive::new()
+                // How long will the connection be allowed to sit idle before the first keepalive
+                // packet is sent?
+                .with_time(Duration::from_secs(30))
+                // How long should we wait between sending keepalive packets?
+                .with_interval(Duration::from_secs(5))
+                // How many keepalive packets should we send before deciding a connection is dead?
+                .with_retries(5),
+        )?;
+    }
 
-    if let Some(stream) = stream {
-        Ok(stream)
-    } else {
-        bail!("Invalid connection params")
+    Ok(sock.into())
+}
+
+// Attempt to connect to each IP address for a remote host and port, returning a `TcpStream` if
+// successful and continuing to try addresses sequentially until one succeeds or we run out.
+fn opportunistic_connect(addrs: Vec<SocketAddr>) -> Result<TcpStream> {
+    let mut last_error = anyhow!("no addresses resolved");
+    for addr in addrs {
+        debug!("attempting to connect to {}", addr);
+        match TcpStream::connect_timeout(&addr, Duration::from_secs(5)) {
+            Ok(stream) => {
+                debug!("connected to {addr}");
+                return Ok(stream);
+            }
+            Err(err) => {
+                debug!("failed to connect to {addr}: {err}");
+                last_error = err.into()
+            }
+        }
+    }
+    Err(last_error)
+}
+
+// Lookup IP addresses for the given host/port, returning a Vec that interleaves IPv6/IPv4 addresses.
+// This makes it easy to prefer IPv6 addresses, but fall-back to IPv4 as we attempt connecting to
+// each address in sequence.
+fn prepare_addresses(host: &str, port: u16) -> Result<Vec<SocketAddr>> {
+    debug!("resolving IP addresses for {host}:{port}");
+    let (addrs_v4, addrs_v6): (Vec<_>, Vec<_>) =
+        (host, port).to_socket_addrs()?.partition(|a| match a {
+            SocketAddr::V4(_) => true,
+            SocketAddr::V6(_) => false,
+        });
+    let mut addrs = Vec::with_capacity(addrs_v4.len() + addrs_v6.len());
+    let (mut left, mut right) = (addrs_v6.into_iter(), addrs_v4.into_iter());
+    while let Some(a) = left.next() {
+        addrs.push(a);
+        std::mem::swap(&mut left, &mut right);
+    }
+    addrs.extend(right);
+    debug!("resolved {} potential addresses", addrs.len());
+    Ok(addrs)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener;
+    use std::sync::mpsc::{channel, Receiver, Sender};
+    use std::thread;
+
+    use socket2::Socket;
+
+    use crate::io::SaveData;
+    use crate::model;
+    use crate::model::KEEPALIVE_ENABLED;
+    use crate::net::open_tcp_stream;
+
+    #[test]
+    fn test_keepalive_disable() {
+        // Start a dummy TCP server on a random port.
+        let listener = TcpListener::bind("0.0.0.0:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx): (Sender<bool>, Receiver<bool>) = channel();
+        let server_handle = thread::spawn(move || {
+            for stream in listener.incoming() {
+                let _stream = stream.unwrap();
+                if rx.recv().unwrap() {
+                    break;
+                }
+            }
+        });
+
+        // Keepalive should default to on.
+        let mut settings = model::Settings::default();
+        assert!(settings.get(KEEPALIVE_ENABLED).unwrap());
+        let stream = open_tcp_stream(addr.ip().to_string().as_str(), addr.port()).unwrap();
+        let sock = Socket::from(stream);
+
+        // The socket should have keepalive enabled since the default settings were used.
+        assert!(sock.keepalive().unwrap());
+        drop(sock);
+
+        // Disable keepalive in settings.
+        settings.set(KEEPALIVE_ENABLED, false).unwrap();
+        assert!(!settings.get(KEEPALIVE_ENABLED).unwrap());
+        settings.save();
+        let stream = open_tcp_stream(addr.ip().to_string().as_str(), addr.port()).unwrap();
+        let sock = Socket::from(stream);
+
+        // Now the socket should not have keepalive enabled.
+        assert!(!sock.keepalive().unwrap());
+
+        // Shut down the server.
+        tx.send(true).unwrap();
+        server_handle.join().unwrap();
     }
 }


### PR DESCRIPTION
This branch updates the `open_tcp_stream` fn from `net/util.rs` to configure the opened socket with [TCP keepalive](https://en.wikipedia.org/wiki/Keepalive#TCP_keepalive) enabled.

This TCP feature is particularly important for MUDs because Telnet has no consistently enabled application layer keepalive feature. Without a keepalive mechanism long-lived and idle Telnet connections are prone to being closed by middlebox routers. When this happens Blightmud won't detect the socket was closed until the user tries to read or write from the socket. Other MUD clients [like Mudlet](https://github.com/Mudlet/Mudlet/blob/31ea3079e63735a344379e714117e4f1ad6b2f1b/src/ctelnet.cpp#L3052-L3138) configure TCP keepalive to compensate for this using a native (but typically default off) TCP feature.

In order to achieve TCP keepalive for Blightmud we take a new dependency on [`socket2`](https://docs.rs/socket2/latest/socket2/), a crate that abstracts over unsafe OS-specific mechanisms for customizing socket options. We use `socket2` to configure the opened socket to start sending TCP keepalives 30 seconds after a connection is detected as idle. Keepalives will be sent every 5 seconds, and we'll tolerate up to 5 lost keepalives before deciding the connection is closed.

We default to configuring TCP keepalive but a new "keepalive_enabled" setting can be set to 'false' by users that don't want this feature for some reason.

The address resolution logic is also changed to prefer IPv6, but fall-back to IPv4. We now interleave IPv6/IPv4 addresses to maximize the chance of finding a working address quickly, while still preferring IPv6 if available. This is a rough aproximation of the "happy eyeballs" approach used by browsers.

Lastly, to aid in future debugging new `debug!` log lines are added for which addresses are resolved, which are tried, and errors encountered trying to connect. Using the debug log level means these won't be present unless Blightmud is run with `-V` for verbose mode.
