### PR TITLE
main: add --no-update-check flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ pub struct RuntimeConfig {
     pub script: Option<String>,
     pub eval: Option<String>,
     pub integration_test: bool,
+    pub no_update_check: bool,
 }
 
 impl From<Matches> for RuntimeConfig {
@@ -157,6 +158,7 @@ impl From<Matches> for RuntimeConfig {
             script: None,
             eval: None,
             integration_test: false,
+            no_update_check: matches.opt_present("no-update-check"),
         }
     }
 }
@@ -284,7 +286,12 @@ fn run(main_thread_read: Receiver<Event>, mut session: Session, rt: RuntimeConfi
             .send(Event::LoadScript(script.to_str().unwrap().to_string()))?;
     }
 
-    check_latest_version(session.main_writer.clone());
+    if !rt.no_update_check {
+        check_latest_version(session.main_writer.clone());
+    } else {
+        info!("Skipping update check");
+    }
+
     if cfg!(not(debug_assertions)) {
         migrate_v2_settings_and_servers(session.main_writer.clone());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,11 @@ fn setup_options() -> Options {
     opts.optflag("v", "version", "Print version information");
     opts.optflag("V", "verbose", "Enable verbose logging");
     opts.optflag("r", "reader-mode", "Force screen reader friendly mode");
+    opts.optflag(
+        "c",
+        "no-update-check",
+        "Skip checking for new Blightmud versions at startup",
+    );
     //opts.optflag("H", "headless-mode", "Runs Blightmud without a TUI");
 
     opts
@@ -93,10 +98,16 @@ mod tests {
 
     #[test]
     fn test_config_parse() {
-        let args: Vec<String> = vec!["blightmud", "--verbose", "--connect", "localhost:8080"]
-            .iter()
-            .map(|s| String::from(*s))
-            .collect();
+        let args: Vec<String> = vec![
+            "blightmud",
+            "--no-update-check",
+            "--verbose",
+            "--connect",
+            "localhost:8080",
+        ]
+        .iter()
+        .map(|s| String::from(*s))
+        .collect();
         let opts = setup_options();
         let matches = match opts.parse(&args[1..]) {
             Ok(m) => m,
@@ -104,6 +115,7 @@ mod tests {
         };
         let rt = RuntimeConfig::from(matches);
         assert!(rt.verbose);
+        assert!(rt.no_update_check);
         assert_eq!(rt.connect, Some("localhost:8080".to_string()));
     }
 }


### PR DESCRIPTION
This commit adds a new command line flag (`-c` or `--no-update-check`) that can be provided to have Blightmud skip checking for new versions at startup (the default behaviour).

This is helpful if:
* The user doesn't want to upgrade for some reason, and would prefer not to see a notice every startup about a new version.
* The user is trying to debug something related to connectivity and doesn't want the verbose logs to have lines interleaved from the GitHub API request used for the version check.

<details>
<summary>Verbose logs at startup without this flag:</summary>

```
[00:00:00.000] (7f1700078a40) INFO   Starting application
[00:00:00.018] (7f1700078a40) DEBUG  Drawing help file: welcome
[00:00:00.018] (7f16fd9c76c0) DEBUG  Input stream spawned
[00:00:00.020] (7f16fd3c46c0) DEBUG  starting new connection: https://api.github.com/
[00:00:00.066] (7f16fd3c46c0) DEBUG  No cached session for DnsName("api.github.com")
[00:00:00.067] (7f16fd3c46c0) DEBUG  Not resuming any session
[00:00:00.098] (7f16fd3c46c0) DEBUG  Using ciphersuite TLS13_AES_128_GCM_SHA256
[00:00:00.098] (7f16fd3c46c0) DEBUG  Not resuming
[00:00:00.098] (7f16fd3c46c0) DEBUG  TLS1.3 encrypted extensions: [ServerNameAck, Protocols([ProtocolName(6832)])]
[00:00:00.098] (7f16fd3c46c0) DEBUG  ALPN protocol is Some(b"h2")
[00:00:01.707] (7f1700078a40) DEBUG  Input sent. Mode: UnterminatedPrompt
[00:00:01.711] (7f1700078a40) INFO   Shutting down
```
</details>

<details>
<summary>Verbose logs at startup with this flag:</summary>

```
[00:00:00.000] (7fabe5a5ea40) INFO   Starting application
[00:00:00.018] (7fabd33fc6c0) DEBUG  Input stream spawned
[00:00:00.018] (7fabe5a5ea40) INFO   Skipping update check
[00:00:00.018] (7fabe5a5ea40) DEBUG  Drawing help file: welcome
[00:00:01.315] (7fabe5a5ea40) DEBUG  Input sent. Mode: UnterminatedPrompt
[00:00:01.320] (7fabe5a5ea40) INFO   Shutting down
```
</details>