### PR TITLE
Fix nightly clippy findings, add CI coverage

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -38,3 +38,27 @@ jobs:
         run: cargo check --locked
       - name: Clippy (all features)
         run: cargo clippy --locked
+  validate-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            ~/.cargo/bin
+          key: ubuntu-latest-check-lint-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Updating repository
+        run: sudo apt-get update
+      - name: Installing dependencies
+        run: sudo apt-get install libasound2-dev libspeechd-dev
+      - name: Setup nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+      - name: Check (all features)
+        run: cargo check --locked
+      - name: Clippy (all features)
+        run: cargo clippy --locked

--- a/src/lua/spellcheck.rs
+++ b/src/lua/spellcheck.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use hunspell_rs::{CheckResult, Hunspell};
 use mlua::prelude::LuaError;
 use mlua::{AnyUserData, Result as LuaResult, String as LuaString, Table, UserData};
-use std::sync::Arc;
+use std::rc::Rc;
 
 pub const LUA_GLOBAL_NAME: &str = "spellcheck";
 
@@ -79,7 +79,7 @@ impl UserData for Spellchecker {
 }
 
 #[derive(Clone)]
-struct HunspellSafe(Arc<Hunspell>);
+struct HunspellSafe(Rc<Hunspell>);
 
 unsafe impl Send for HunspellSafe {}
 
@@ -92,7 +92,7 @@ impl std::ops::Deref for HunspellSafe {
 
 impl From<Hunspell> for HunspellSafe {
     fn from(hunspell: Hunspell) -> Self {
-        Self(Arc::new(hunspell))
+        Self(Rc::new(hunspell))
     }
 }
 

--- a/src/net/check_version.rs
+++ b/src/net/check_version.rs
@@ -71,7 +71,7 @@ fn run(writer: Sender<Event>, current: impl AsRef<str>, fetcher: &dyn FetchVersi
         if let Ordering::Greater = latest.version.as_str().cmp(current) {
             // Write information about how to update.
             let (new, url) = (latest.version, latest.url);
-            for msg in vec![
+            for msg in [
                 format!(
                     "There is a newer version of Blightmud available. (current: {current}, new: {new})",
                 ),


### PR DESCRIPTION
Two fixes for `cargo clippy` findings present with Nightly clippy. To catch these sooner in the future CI is updated to run `cargo check` and `cargo clippy` with the latest nightly toolchain in addition to stable.