### PR TITLE
Adds "graceful" handling of protocol disable negotation

### DIFF
--- a/resources/help/core.md
+++ b/resources/help/core.md
@@ -35,6 +35,23 @@ end)
 
 ##
 
+***core.on_protocol_disabled(callback)***
+A callback to receive updates when protocols are disabled. This will trigger
+for all protocols so make sure the one you are interested in is the one
+supplied.
+
+- `callback`  A callback function that takes a u8 as an argument
+
+```lua
+core.on_protocol_disabled(function (proto)
+    if proto == 201 then -- Check for GMCP
+        -- Do your stuff
+    end
+end)
+```
+
+##
+
 ***core.subneg_send(proto, data)***
 Send a subnegotation to the mud. This will send an `IAC SB proto data IAC SE`
 to the mud.

--- a/resources/lua/gmcp.lua
+++ b/resources/lua/gmcp.lua
@@ -46,6 +46,13 @@ local function GMCP()
         end
     end
 
+    local _on_disable = function (proto)
+        if proto == OPT then
+            mud.remove_tag("GMCP");
+            self.gmcp_ready = false
+        end
+    end
+
     -- Convert a table of integer byte values to a UTF-8 encoded string, supporting
     -- multi-byte characters.
     local function _utf8_from(t)
@@ -124,6 +131,7 @@ local function GMCP()
         echo = echo,
         _subneg_recv = _subneg_recv,
         _on_enable = _on_enable,
+        _on_disable = _on_disable,
         _reset = _reset,
     }
 end
@@ -134,6 +142,9 @@ local gmcp = GMCP()
 core.enable_protocol(OPT)
 core.on_protocol_enabled(function (proto)
     gmcp._on_enable(proto)
+end)
+core.on_protocol_disabled(function (proto)
+    gmcp._on_disable(proto)
 end)
 core.subneg_recv(function (proto, data)
     gmcp._subneg_recv(proto, data)

--- a/resources/lua/msdp.lua
+++ b/resources/lua/msdp.lua
@@ -251,6 +251,12 @@ function msdp()
         end
     end
 
+    local _on_disable = function ()
+        mud.remove_tag("MSDP")
+        self.enabled = false
+        store.session_write("__msdp_enabled", tostring(false))
+    end
+
     local _subneg_recv = function (data)
         local recv = decode(data)
         store_content(recv)
@@ -271,6 +277,7 @@ function msdp()
 
     return {
         _on_enable = _on_enable,
+        _on_disable = _on_disable,
         _subneg_recv = _subneg_recv,
         _reset = _reset,
         get = get,
@@ -289,6 +296,11 @@ core.enable_protocol(MSDP)
 core.on_protocol_enabled(function (proto) 
     if proto == MSDP then
         msdp._on_enable()
+    end
+end)
+core.on_protocol_disabled(function (proto) 
+    if proto == MSDP then
+        msdp._on_disable()
     end
 end)
 core.subneg_recv(function (proto, data)

--- a/resources/lua/naws.lua
+++ b/resources/lua/naws.lua
@@ -35,6 +35,13 @@ core.on_protocol_enabled(function (proto)
     end
 end)
 
+core.on_protocol_disabled(function (proto)
+    if proto == NAWS_PROTOCOL then
+        mud.remove_tag("NAWS")
+        naws_enabled = false
+    end
+end)
+
 -- When dimensions change, send an updated NAWS message when enabled.
 blight.on_dimensions_change(function (width, height)
     if naws_enabled then

--- a/resources/lua/telnet_charset.lua
+++ b/resources/lua/telnet_charset.lua
@@ -72,3 +72,9 @@ core.on_protocol_enabled(function (proto)
         mud.add_tag("TELCHR")
     end
 end)
+
+core.on_protocol_disabled(function (proto)
+    if proto == PROTOCOL then
+        mud.remove_tag("TELCHR")
+    end
+end)

--- a/resources/lua/ttype.lua
+++ b/resources/lua/ttype.lua
@@ -87,6 +87,13 @@ core.on_protocol_enabled(function (proto)
     end
 end)
 
+core.on_protocol_disabled(function (proto)
+    if proto == 24 then
+        mud.remove_tag("TTYPE")
+        init()
+    end
+end)
+
 function mod.set_term(new_term)
     term = new_term
     Info(string.format("Set TERM: %s", term))

--- a/src/event.rs
+++ b/src/event.rs
@@ -51,6 +51,7 @@ pub enum Event {
     PlayMusic(String, SourceOptions),
     PlaySFX(String, SourceOptions),
     Prompt(Line),
+    ProtoDisabled(u8),
     ProtoEnabled(u8),
     ProtoSubnegRecv(u8, Bytes),
     ProtoSubnegSend(u8, Bytes),
@@ -58,6 +59,7 @@ pub enum Event {
     QuitConfirmTimeout,
     Reconnect,
     Redraw,
+    RemoveTag(String),
     RemoveTimer(u32),
     ResetScript,
     ScrollBottom,
@@ -339,6 +341,7 @@ impl EventHandler {
                 Ok(())
             }
             Event::AddTag(tag) => screen.add_tag(&tag),
+            Event::RemoveTag(tag) => screen.remove_tag(&tag),
             _ => Err(BadEventRoutingError.into()),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,7 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
             | Event::Error(_)
             | Event::Info(_)
             | Event::AddTag(_)
+            | Event::RemoveTag(_)
             | Event::ClearTags
             | Event::UserInputBuffer(_, _)
             | Event::UserInputCursor(_)
@@ -425,6 +426,14 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
                             session.main_writer.send(Event::ServerSend(data)).unwrap();
                         }
                     }
+                }
+            }
+            Event::ProtoDisabled(proto) => {
+                if let Ok(mut lua) = session.lua_script.lock() {
+                    lua.proto_disabled(proto);
+                    lua.get_output_lines().iter().for_each(|l| {
+                        screen.print_output(l);
+                    });
                 }
             }
             Event::ProtoEnabled(proto) => {

--- a/src/lua/constants.rs
+++ b/src/lua/constants.rs
@@ -24,4 +24,5 @@ pub const STATUS_AREA_HEIGHT: &str = "__status_area_height";
 
 // Core tables
 pub const PROTO_ENABLED_LISTENERS_TABLE: &str = "__protocol_enabled_listeners";
+pub const PROTO_DISABLED_LISTENERS_TABLE: &str = "__protocol_disabled_listeners";
 pub const PROTO_SUBNEG_LISTENERS_TABLE: &str = "__protocol_subneg_listeners";

--- a/src/lua/core.rs
+++ b/src/lua/core.rs
@@ -7,7 +7,9 @@ use mlua::{AnyUserData, Table, UserData, UserDataMethods};
 use crate::{event::Event, io::exec};
 
 use super::{
-    constants::{PROTO_ENABLED_LISTENERS_TABLE, PROTO_SUBNEG_LISTENERS_TABLE},
+    constants::{
+        PROTO_DISABLED_LISTENERS_TABLE, PROTO_ENABLED_LISTENERS_TABLE, PROTO_SUBNEG_LISTENERS_TABLE,
+    },
     exec_response::ExecResponse,
 };
 
@@ -51,6 +53,14 @@ impl UserData for Core {
             let mut this = this_aux.borrow_mut::<Core>()?;
             table.set(this.next_index(), cb)?;
             ctx.set_named_registry_value(PROTO_ENABLED_LISTENERS_TABLE, table)?;
+            Ok(())
+        });
+        methods.add_function_mut("on_protocol_disabled", |ctx, cb: mlua::Function| {
+            let table: Table = ctx.named_registry_value(PROTO_DISABLED_LISTENERS_TABLE)?;
+            let this_aux = ctx.globals().get::<_, AnyUserData>("core")?;
+            let mut this = this_aux.borrow_mut::<Core>()?;
+            table.set(this.next_index(), cb)?;
+            ctx.set_named_registry_value(PROTO_DISABLED_LISTENERS_TABLE, table)?;
             Ok(())
         });
         methods.add_function_mut("subneg_recv", |ctx, cb: mlua::Function| {

--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -134,6 +134,7 @@ fn create_default_lua_state(builder: LuaScriptBuilder, store: Option<Store>) -> 
         state.set_named_registry_value(TIMER_TICK_CALLBACK_TABLE_CORE, state.create_table()?)?;
         state.set_named_registry_value(COMMAND_BINDING_TABLE, state.create_table()?)?;
         state.set_named_registry_value(PROTO_ENABLED_LISTENERS_TABLE, state.create_table()?)?;
+        state.set_named_registry_value(PROTO_DISABLED_LISTENERS_TABLE, state.create_table()?)?;
         state.set_named_registry_value(PROTO_SUBNEG_LISTENERS_TABLE, state.create_table()?)?;
         state.set_named_registry_value(ON_CONNECTION_CALLBACK_TABLE, state.create_table()?)?;
         state.set_named_registry_value(ON_DISCONNECT_CALLBACK_TABLE, state.create_table()?)?;
@@ -491,6 +492,19 @@ impl LuaScript {
                 Ok(())
             });
         }
+    }
+
+    pub fn proto_disabled(&mut self, proto: u8) {
+        self.exec_lua(&mut || -> LuaResult<()> {
+            let table: mlua::Table = self
+                .state
+                .named_registry_value(PROTO_DISABLED_LISTENERS_TABLE)?;
+            for pair in table.pairs::<mlua::Value, mlua::Function>() {
+                let (_, cb) = pair.unwrap();
+                cb.call::<_, ()>(proto)?;
+            }
+            Ok(())
+        });
     }
 
     pub fn proto_enabled(&mut self, proto: u8) {

--- a/src/lua/mud.rs
+++ b/src/lua/mud.rs
@@ -126,6 +126,11 @@ impl UserData for Mud {
             backend.writer.send(Event::AddTag(tag)).unwrap();
             Ok(())
         });
+        methods.add_function("remove_tag", |ctx, tag: String| {
+            let backend: Backend = ctx.named_registry_value(BACKEND)?;
+            backend.writer.send(Event::RemoveTag(tag)).unwrap();
+            Ok(())
+        });
         methods.add_function("clear_tags", |ctx, ()| {
             let backend: Backend = ctx.named_registry_value(BACKEND)?;
             backend.writer.send(Event::ClearTags).unwrap();

--- a/src/net/telnet.rs
+++ b/src/net/telnet.rs
@@ -37,7 +37,7 @@ impl TelnetHandler {
         }
     }
 
-    fn determine_telnet_mode(&mut self) {
+    fn update_telnet_mode(&mut self) {
         self.mode = if self.will_ga || self.will_eor {
             TelnetMode::TerminatedPrompt
         } else {
@@ -51,12 +51,12 @@ impl TelnetHandler {
 
     pub fn toggle_ga(&mut self, will: bool) {
         self.will_ga = will;
-        self.determine_telnet_mode();
+        self.update_telnet_mode();
     }
 
     pub fn toggle_eor(&mut self, will: bool) {
         self.will_eor = will;
-        self.determine_telnet_mode();
+        self.update_telnet_mode();
     }
 
     pub fn parse(&mut self, data: &[u8]) -> Option<Vec<u8>> {

--- a/src/ui/headless_screen.rs
+++ b/src/ui/headless_screen.rs
@@ -79,6 +79,10 @@ impl UserInterface for HeadlessScreen {
         Ok(())
     }
 
+    fn remove_tag(&mut self, _proto: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     fn clear_tags(&mut self) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/ui/reader_screen.rs
+++ b/src/ui/reader_screen.rs
@@ -389,6 +389,10 @@ impl UserInterface for ReaderScreen {
         Ok(())
     }
 
+    fn remove_tag(&mut self, _: &str) -> Result<()> {
+        Ok(())
+    }
+
     fn clear_tags(&mut self) -> Result<()> {
         Ok(())
     }

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -463,6 +463,11 @@ impl UserInterface for SplitScreen {
         self.redraw_top_bar()
     }
 
+    fn remove_tag(&mut self, tag: &str) -> Result<()> {
+        self.tags.remove(tag);
+        self.redraw_top_bar()
+    }
+
     fn clear_tags(&mut self) -> Result<()> {
         self.tags.clear();
         self.redraw_top_bar()

--- a/src/ui/ui_wrapper.rs
+++ b/src/ui/ui_wrapper.rs
@@ -155,6 +155,10 @@ impl UserInterface for UiWrapper {
         self.screen.add_tag(proto)
     }
 
+    fn remove_tag(&mut self, proto: &str) -> Result<()> {
+        self.screen.remove_tag(proto)
+    }
+
     fn clear_tags(&mut self) -> Result<()> {
         self.screen.clear_tags()
     }

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -50,6 +50,7 @@ pub trait UserInterface {
     fn find_down(&mut self, pattern: &Regex) -> Result<()>;
     fn set_host(&mut self, host: &str, port: u16) -> Result<()>;
     fn add_tag(&mut self, proto: &str) -> Result<()>;
+    fn remove_tag(&mut self, proto: &str) -> Result<()>;
     fn clear_tags(&mut self) -> Result<()>;
     fn set_status_area_height(&mut self, height: u16) -> Result<()>;
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()>;


### PR DESCRIPTION
Since the standard compliance on most mud codebases is "iffy" at best we never really introduced any handling for IAC WONT PROTO negotiation. Although compliance hasn't really changed among the various codebases it will avoid confusion if Blightmud would correctly pick up on and "disable" protocols locally when the mud requests it.

To facilitate this, functionality to listen for protocol disable requests as well as removing tags (topbar tags) have been introduced across the board.