### PR TITLE
Move scroll default bindings to lua

### DIFF
--- a/resources/help/bindings.md
+++ b/resources/help/bindings.md
@@ -83,6 +83,12 @@ bind("ctrl-u", "delete_from_start")
 bind("ctrl-k", "delete_to_end")
 bind("ctrl-u", "delete_from_start")
 
+-- Scrolling
+bind("home", "scroll_top")
+bind("end", "scroll_bottom")
+bind("pageup", "scroll_up")
+bind("pagedown", "scroll_down")
+
 -- ctrl + up/down
 blight.bind("\x1b[1;5a", function () search.find_up() end)
 blight.bind("\x1b[1;5b", function () search.find_down() end)

--- a/resources/lua/bindings.lua
+++ b/resources/lua/bindings.lua
@@ -17,6 +17,12 @@ bind("ctrl-h", "delete")
 bind("ctrl-k", "delete_to_end")
 bind("ctrl-u", "delete_from_start")
 
+-- Scrolling
+bind("home", "scroll_top")
+bind("end", "scroll_bottom")
+bind("pageup", "scroll_up")
+bind("pagedown", "scroll_down")
+
 -- ctrl + up/down
 blight.bind("\x1b[1;5a", function () search.find_up() end)
 blight.bind("\x1b[1;5b", function () search.find_down() end)

--- a/src/ui/command.rs
+++ b/src/ui/command.rs
@@ -299,10 +299,6 @@ fn parse_key_event(
         Key::Ctrl('c') => {
             writer.send(Event::Quit(QuitMethod::CtrlC)).unwrap();
         }
-        Key::PageUp => writer.send(Event::ScrollUp).unwrap(),
-        Key::PageDown => writer.send(Event::ScrollDown).unwrap(),
-        Key::Home => writer.send(Event::ScrollTop).unwrap(),
-        Key::End => writer.send(Event::ScrollBottom).unwrap(),
 
         // Input navigation
         Key::Left => buffer.step_left(),


### PR DESCRIPTION
The default bindings home, end, pgup, pgdn were implemented in rust. At
the same time these bindings are perfectly fine to do in lua but weren't
documented as such or implemented.

This patch moves the default scroll bindings to lua and documents them
in the helpfile. They have also been removed from the rust code since it
serves no purpose leaving them in there.

It is better to limit the "rust bindings" to core commands that aren't
bindable by users.
