### PR TITLE
deps: update to rustls 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,8 +266,9 @@ dependencies = [
  "rodio",
  "ron",
  "rs-complete",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.22.0",
+ "rustls-pemfile 2.0.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "signal-hook",
@@ -279,7 +280,7 @@ dependencies = [
  "timer",
  "tts",
  "vte 0.13.0",
- "webpki-roots",
+ "webpki-roots 0.26.0",
 ]
 
 [[package]]
@@ -975,7 +976,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls",
+ "rustls 0.21.9",
  "tokio",
  "tokio-rustls",
 ]
@@ -2087,8 +2088,8 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.21.9",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2100,7 +2101,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.3",
  "winreg",
 ]
 
@@ -2185,8 +2186,22 @@ checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc238b76c51bbc449c55ffbc39d03772a057cc8cf783c49d4af4c2537b74a8b"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2199,12 +2214,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+dependencies = [
+ "base64",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb0a1f9b9efec70d32e6d6aa3e58ebd88c3754ec98dfe9145c63cf54cc829b83"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2635c8bc2b88d367767c5de8ea1d8db9af3f6219eba28442242d9ab81d1b89"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2408,6 +2450,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "symphonia"
@@ -2676,7 +2724,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.9",
  "tokio",
 ]
 
@@ -3030,6 +3078,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2cfda980f21be5a7ed2eadb3e6fe074d56022bea2cdeb1a62eb220fc04188"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3272,3 +3329,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,15 +47,16 @@ rodio = "0.17.3"
 notify-debouncer-mini = "0.4.1"
 hunspell-rs = { version = "0.4.0", optional = true }
 hunspell-sys = { version = "0.3.0", features = ['bundled'], optional = true }
-rustls = { version = "0.21.9", features = ['dangerous_configuration'] }
-webpki-roots = { version = "0.25.3" }
+rustls = "0.22"
+rustls-pki-types = "1.0"
+webpki-roots = "0.26"
 reqwest = { version = "0.11.22", default-features = false, features = ['blocking', 'rustls-tls', 'json'] }
 socket2 = "0.5.5"
 
 [dev-dependencies]
 mockall = "0.11.4"
 mockall_double = "0.3.0"
-rustls-pemfile = "1.0.4"
+rustls-pemfile = "2.0"
 env_logger = "0.10.1"
 
 [profile.dev.package.hunspell-sys]

--- a/src/net/tls.rs
+++ b/src/net/tls.rs
@@ -1,6 +1,7 @@
 use crate::net::RwStream;
 use anyhow::Result;
-use rustls::{ClientConfig, ClientConnection, OwnedTrustAnchor, RootCertStore, StreamOwned};
+use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+use rustls_pki_types::ServerName;
 use std::fmt::{Display, Formatter};
 use std::net::TcpStream;
 use std::sync::Arc;
@@ -68,7 +69,6 @@ impl TlsStream {
         roots: RootCertStore,
     ) -> Result<TlsStream> {
         let mut config = ClientConfig::builder()
-            .with_safe_defaults()
             .with_root_certificates(roots)
             .with_no_client_auth();
 
@@ -83,43 +83,74 @@ impl TlsStream {
                 .dangerous()
                 .set_certificate_verifier(Arc::new(danger::NoCertificateVerification {}));
         };
-        let server_name = host.try_into()?;
+        let server_name = ServerName::try_from(host)?.to_owned();
         let conn = ClientConnection::new(Arc::new(config), server_name)?;
         Ok(RwStream::new(StreamOwned::new(conn, stream)))
     }
 
     fn default_root_certs() -> RootCertStore {
-        let mut root_store = RootCertStore::empty();
-        root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
-            OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        }));
-        root_store
+        RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.iter().cloned().collect(),
+        }
     }
 }
 
 /// here be dragons.
 mod danger {
-    use rustls::{client, Certificate, ServerName};
+    use rustls::client::danger::HandshakeSignatureValid;
+    use rustls::crypto::{verify_tls12_signature, verify_tls13_signature};
+    use rustls::{client, DigitallySignedStruct, Error, SignatureScheme};
+    use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
 
-    /// NoCertificateVerification is a **DANGEROUS** [client::ServerCertVerifier] that
+    /// NoCertificateVerification is a **DANGEROUS** [client::danger::ServerCertVerifier] that
     /// performs **no** certificate validation.
+    #[derive(Debug)]
     pub struct NoCertificateVerification {}
 
-    impl client::ServerCertVerifier for NoCertificateVerification {
+    impl client::danger::ServerCertVerifier for NoCertificateVerification {
         fn verify_server_cert(
             &self,
-            _end_entity: &Certificate,
-            _intermediates: &[Certificate],
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
             _server_name: &ServerName,
-            _scts: &mut dyn Iterator<Item = &[u8]>,
             _ocsp: &[u8],
-            _now: std::time::SystemTime,
-        ) -> Result<client::ServerCertVerified, rustls::Error> {
-            Ok(client::ServerCertVerified::assertion())
+            _now: UnixTime,
+        ) -> Result<client::danger::ServerCertVerified, Error> {
+            Ok(client::danger::ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, Error> {
+            verify_tls12_signature(
+                message,
+                cert,
+                dss,
+                &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+            )
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, Error> {
+            verify_tls13_signature(
+                message,
+                cert,
+                dss,
+                &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+            )
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            rustls::crypto::ring::default_provider()
+                .signature_verification_algorithms
+                .supported_schemes()
         }
     }
 }
@@ -130,9 +161,10 @@ mod test_tls {
     use crate::net::CertificateValidation;
     use log::debug;
     use rustls::{
-        Certificate, CertificateError, Error::InvalidCertificate, PrivateKey, RootCertStore,
-        ServerConfig, ServerConnection, StreamOwned,
+        CertificateError, Error::InvalidCertificate, RootCertStore, ServerConfig, ServerConnection,
+        StreamOwned,
     };
+    use rustls_pki_types::{CertificateDer, PrivateKeyDer};
     use std::io::{BufReader, Read};
     use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
     use std::sync::Arc;
@@ -144,35 +176,26 @@ mod test_tls {
     const TEST_SERVER_KEY: &str = "tests/certs/localhost/key.pem";
     const TEST_CA_CERTS: &str = "tests/certs/minica.pem";
 
-    fn load_certs(filename: &str) -> Vec<Certificate> {
+    fn load_certs(filename: &str) -> Vec<CertificateDer<'_>> {
         let certfile = fs::File::open(filename).expect("cannot open certificate file");
         let mut reader = BufReader::new(certfile);
         rustls_pemfile::certs(&mut reader)
-            .unwrap()
-            .iter()
-            .map(|v| Certificate(v.clone()))
+            .map(|der| der.unwrap())
             .collect()
     }
 
-    fn load_private_key(filename: &str) -> PrivateKey {
+    fn load_private_key(filename: &str) -> PrivateKeyDer<'_> {
         let keyfile = fs::File::open(filename).expect("cannot open private key file");
         let mut reader = BufReader::new(keyfile);
 
-        loop {
-            match rustls_pemfile::read_one(&mut reader).expect("cannot parse private key .pem file")
-            {
-                Some(rustls_pemfile::Item::RSAKey(key)) => return PrivateKey(key),
-                None => break,
-                _ => {}
-            }
-        }
-
-        panic!("no keys found in {:?}", filename);
+        rustls_pemfile::private_key(&mut reader)
+            .expect("cannot parse private key .pem file")
+            .expect("no private keys found in file")
     }
 
     fn test_ca_roots() -> RootCertStore {
         let mut root_store = RootCertStore::empty();
-        load_certs(TEST_CA_CERTS).iter().for_each(|c| {
+        load_certs(TEST_CA_CERTS).into_iter().for_each(|c| {
             root_store.add(c).unwrap();
         });
         root_store
@@ -183,7 +206,6 @@ mod test_tls {
         let priv_key = load_private_key(TEST_SERVER_KEY);
         let config = Arc::new(
             ServerConfig::builder()
-                .with_safe_defaults()
                 .with_no_client_auth()
                 .with_single_cert(cert_chain, priv_key)
                 .unwrap(),


### PR DESCRIPTION
This branch updates Blightmud to use [Rustls 0.22](https://github.com/rustls/rustls/releases/tag/v%2F0.22.0). To do so, we:

* take a new dependency on rustls-pki-types 1.0 - where types shared across common rustls crates now live.
* update the webpki-roots dependency to 0.26 to match the Rustls 0.22 pki-types version.
* update the rustls-pemfile dev dep to 2.0 to match the Rustls 0.22 pki-types version.
* fix breaking API changes

Opened as a draft for now, because we probably want to wait until there's a `reqwest` version available that uses the same Rustls and webpki-roots versions, otherwise we'll inflate build times/binary size having two versions in-tree. Since Rustls 0.22 was cut today it will take some time for the update to percolate through the ecosystem.