### PR TITLE
net: log mud receiver stream read errors

### DIFF
--- a/src/net/tcp_stream.rs
+++ b/src/net/tcp_stream.rs
@@ -48,11 +48,17 @@ impl MudReceiver {
                     data = vec![];
                 }
             }
-        } else if let Ok(bytes_read) = self.connection.read(&mut data) {
-            debug!("Read {} bytes from stream", bytes_read);
-            data = data[..bytes_read].to_vec();
         } else {
-            data = vec![];
+            match self.connection.read(&mut data) {
+                Ok(bytes_read) => {
+                    debug!("Read {bytes_read} bytes from stream");
+                    data = data[..bytes_read].to_vec();
+                }
+                Err(err) => {
+                    error!("Error: {err}");
+                    data = vec![];
+                }
+            }
         }
         debug!("Bytes: {:?}", data);
         data


### PR DESCRIPTION
Previously the `MudReceiver` logic that could potentially read an `Error` result from `self.connection.read(&mut data)` only used the `Ok` result. If there was an error, `data` is set to the empty vec and a higher layer treats the empty data as an EOF initiated disconnect. The error is dropped.

This commit breaks out the result handling to log a read error with `error!`, and otherwise maintains the existing behaviour: returning an empty vec.