### PR TITLE
 termion 2.0.3 -> 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "2.0.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4648c7def6f2043b2568617b9f9b75eae88ca185dbc1f1fda30e95a85d49d7d"
+checksum = "417813675a504dfbbf21bfde32c03e5bf9f2413999962b479023c02848c1c7a5"
 dependencies = [
  "libc",
  "libredox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ spellcheck = ["hunspell-rs", "hunspell-sys"]
 
 [dependencies]
 libmudtelnet = "2.0.1"
-termion = "2.0.3"
+termion = "3"
 log = "0.4.20"
 simple-logging = "2.0.2"
 chrono = "0.4.31"

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698318101,
-        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
+        "lastModified": 1704722960,
+        "narHash": "sha256-mKGJ3sPsT6//s+Knglai5YflJUF2DGj7Ai6Ynopz0kI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
+        "rev": "317484b1ead87b9c1b8ac5261a8d2dd748a0492d",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1698458995,
-        "narHash": "sha256-nF8E8Ur5NggwPQNp3w/fddWmQrNEwCm0dgz6tk8Ew6E=",
+        "lastModified": 1705025860,
+        "narHash": "sha256-9vcqo5CJLOHU63S7pVlP0u4OhgJxrXebQR4vqMPXLRg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "571fee291b386dd6fe0d125bc20a7c7b3ad042ac",
+        "rev": "d458975da373a37422577886566fce8201bc1254",
         "type": "github"
       },
       "original": {

--- a/src/ui/ui_wrapper.rs
+++ b/src/ui/ui_wrapper.rs
@@ -16,7 +16,7 @@ use termion::{input::MouseTerminal, raw::IntoRawMode, screen::IntoAlternateScree
 
 /// Creates the io::Write terminal handler we draw to.
 fn create_screen_writer(mouse_support: bool) -> Result<Box<dyn Write>> {
-    let screen = stdout().into_alternate_screen()?.into_raw_mode()?;
+    let screen = stdout().into_raw_mode()?.into_alternate_screen()?;
     if mouse_support {
         Ok(Box::new(MouseTerminal::from(screen)))
     } else {


### PR DESCRIPTION
Replaces https://github.com/Blightmud/Blightmud/pull/976

The termion crate's own [alternative screen raw example](https://gitlab.redox-os.org/redox-os/termion/-/blob/b4ed9fad4e14ab4238d4c0dbe0ca18d67ff839bd/examples/alternate_screen_raw.rs#L19) initializes stdout, then puts it in raw mode, and then goes into the alternate screen mode.

Blightmud was reversing those last two steps; going into alt screen mode and then raw mode. This works with termion 2.x but with 3.x it fails when `into_raw_mode tries` to move its arg out of the alternative screen:

```
cannot move out of dereference of `AlternateScreen<Stdout>`
```

This commit adjusts the `ui_wrapper` `create_screen_writer` fn to match the order the termion example uses, then updates to termion 3.x. I also updated the Nix `flake.lock` while I'm here.