### PR TITLE
Fix release script and drop changelog gen

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -9,7 +9,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  package_ubuntu_22_04:
+  package_ubuntu_latest:
     name: Build deb & rpm
     runs-on: ubuntu-latest
     steps:
@@ -34,13 +34,6 @@ jobs:
         id: rpm_path
         run: |
           ls -1 target/release/rpmbuild/RPMS/x86_64/*.rpm | awk '{print "rpm_path="$1}' >> $GITHUB_OUTPUT
-      - name: Generate changelog
-        id: changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.4
-        with:
-          onlyLastTag: true
-          filterByMilestone: true
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create/Update release
         uses: ncipollo/release-action@v1
         with:

--- a/scripts/blightmud-release.sh
+++ b/scripts/blightmud-release.sh
@@ -17,15 +17,15 @@ fi
 
 echo -n "Downloading Mac releases... "
 curl -L https://github.com/Blightmud/Blightmud/releases/download/v${VERSION}/blightmud-v${VERSION}-macos.zip --output blightmud-mac.zip > /dev/null 2>&1
-curl -L https://github.com/Blightmud/Blightmud/releases/download/v${VERSION}/blightmud-v${VERSION}-macos-11.zip --output blightmud-mac-11.zip > /dev/null 2>&1
+curl -L https://github.com/Blightmud/Blightmud/releases/download/v${VERSION}/blightmud-v${VERSION}-macos-13.zip --output blightmud-mac-13.zip > /dev/null 2>&1
 echo "Done"
 echo -n "Getting sha256 sum... "
 SHA256_LATEST=$(sha256sum blightmud-mac.zip | cut --delimiter=" " -f1)
-SHA256_11=$(sha256sum blightmud-mac-11.zip | cut --delimiter=" " -f1)
+SHA256_13=$(sha256sum blightmud-mac-13.zip | cut --delimiter=" " -f1)
 echo "Done"
 echo -n "Deleting files... "
 rm blightmud-mac.zip
-rm blightmud-mac-11.zip
+rm blightmud-mac-13.zip
 echo "Done"
 
 cd homebrew-blightmud
@@ -37,7 +37,7 @@ sed -i -e"s/  version \".*\"/  version \"${VERSION}\"/" Formula/blightmud.rb
 sed -i -e"s/  sha256 \".*\"/  sha256 \"${SHA256_LATEST}\"/" Formula/blightmud.rb
 echo "Done"
 echo "MacOS (latest) sha256: ${SHA256_LATEST}"
-echo "MacOS (11) sha256: ${SHA256_11}"
+echo "MacOS (13) sha256: ${SHA256_13}"
 
 echo -n "Pushing changes... "
 git commit -a -m"Version ${VERSION}" > /dev/null 2>&1


### PR DESCRIPTION
Fixes the release script to no longer use macos-11 and removes the
changelog generator from the release build.
