### PR TITLE
Prepend plugin name in require when loading plugin

### DIFF
--- a/resources/lua/functions.lua
+++ b/resources/lua/functions.lua
@@ -28,3 +28,13 @@ function cformat(msg, ...)
 
   return msg:format(...)
 end
+
+local global_require = require
+function make_plugin_require(plugin_name)
+    return function(mod_name)
+        if not mod_name:match("^/") then
+            mod_name = plugin_name .. "/" .. mod_name
+        end
+        return global_require(mod_name)
+    end
+end

--- a/resources/lua/on_state_created.lua
+++ b/resources/lua/on_state_created.lua
@@ -1,3 +1,8 @@
+-- allows require("<plugin name>/<module path>")
+package.path = plugin.dir() .. "/?.lua;" ..
+               plugin.dir() ..  "/?/init.lua;" ..
+               package.path
+
 local function auto_load_plugins()
     local plugins = plugin.enabled()
     for _,p in ipairs(plugins) do

--- a/src/event.rs
+++ b/src/event.rs
@@ -46,6 +46,7 @@ pub enum Event {
     Info(String),
     LoadScript(String),
     EvalScript(String),
+    LoadPlugin(String, String),
     MudOutput(Line),
     Output(Line),
     PlayMusic(String, SourceOptions),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,6 +484,18 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
                     });
                 }
             }
+            Event::LoadPlugin(name, entrypoint_path) => {
+                info!("Loading plugin: {}", name);
+                let mut lua = session.lua_script.lock().unwrap();
+                if let Err(err) = lua.load_plugin(&name, &entrypoint_path) {
+                    screen.print_error(&format!("Failed to load plugin: {err}"));
+                } else {
+                    screen.print_info(&format!("Loaded plugin: {name}"));
+                    lua.get_output_lines().iter().for_each(|l| {
+                        screen.print_output(l);
+                    });
+                }
+            }
             Event::EvalScript(script) => {
                 let mut lua = session.lua_script.lock().unwrap();
                 if let Err(err) = lua.eval(&script) {

--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -16,7 +16,7 @@ use crate::model::Completions;
 use crate::tools::util::expand_tilde;
 use crate::{event::Event, lua::servers::Servers, model, model::Line};
 use anyhow::Result;
-use log::{debug, info};
+use log::debug;
 use mlua::{AnyUserData, FromLua, Lua, Result as LuaResult, Value};
 use std::io::prelude::*;
 use std::path::Path;
@@ -399,22 +399,34 @@ impl LuaScript {
         });
     }
 
-    pub fn load_script(&mut self, path: &str) -> Result<()> {
-        info!("Loading: {}", path);
-        let file_path = expand_tilde(path);
-        let mut file = File::open(file_path.as_ref())?;
-        let dir = file_path.rsplit_once('/').unwrap_or(("", "")).0;
+    pub fn load(&mut self, path: &str) -> Result<()> {
+        let mut file = File::open(path)?;
         let mut content = String::new();
         file.read_to_string(&mut content)?;
-        self.exec_lua(&mut || -> LuaResult<()> {
-            let package: mlua::Table = self.state.globals().get("package")?;
-            let ppath = package.get::<String>("path")?;
-            package.set("path", format!("{dir}/?.lua;{ppath}"))?;
-            let result = self.state.load(&content).set_name(path).exec();
-            package.set("path", ppath)?;
-            result
-        });
+        self.exec_lua(&mut || -> LuaResult<()> { self.state.load(&content).set_name(path).exec() });
         Ok(())
+    }
+
+    pub fn load_script(&mut self, path: &str) -> Result<()> {
+        let expanded_path = expand_tilde(path);
+        let dir = expanded_path.rsplit_once('/').unwrap_or(("", "")).0;
+        let globals: mlua::Table = self.state.globals();
+        let package = globals.get::<mlua::Table>("package")?;
+        let ppath = package.get::<String>("path")?;
+        package.set("path", format!("{dir}/?.lua;{ppath}"))?;
+        let result = self.load(expanded_path.as_ref());
+        package.set("path", ppath)?;
+        result
+    }
+
+    pub fn load_plugin(&mut self, name: &str, entrypoint_path: &str) -> Result<()> {
+        let globals: mlua::Table = self.state.globals();
+        let global_require = globals.get::<mlua::Function>("require")?;
+        let make_require = globals.get::<mlua::Function>("make_plugin_require")?;
+        globals.set("require", make_require.call::<mlua::Function>(name)?)?;
+        let result = self.load(entrypoint_path);
+        globals.set("require", global_require)?;
+        result
     }
 
     pub fn eval(&mut self, script: &str) -> Result<()> {

--- a/src/lua/plugin/functions.rs
+++ b/src/lua/plugin/functions.rs
@@ -132,7 +132,7 @@ pub fn load_plugin(name: &str, writer: &Sender<Event>) -> Result<()> {
         bail!("Plugin '{}' doesn't contain a 'main.lua' file", name);
     } else if let Some(path_name) = path.to_str() {
         writer
-            .send(Event::LoadScript(path_name.to_string()))
+            .send(Event::LoadPlugin(name.to_string(), path_name.to_string()))
             .unwrap();
     } else {
         bail!("Invalid plugin path to main.lua");


### PR DESCRIPTION
When loading a plugin, the global require function is replaced with one that prepends the plugin path to the module path when passed a relative path, i.e. `require("<module path>")` becomes `require("<plugin_name>/<module_path>")`.

* Fixes #1059
* Modules from plugins can now also be loaded from the REPL with `require("<plugin_name>/<module_path>")`

The current draft implementation has a big caveat - see [my comment](https://github.com/Blightmud/Blightmud/issues/1059#issuecomment-3501057136) on issue #1059.