### PR TITLE
Run in Termux on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ me to the word **blight** and here we are.
 - **Cargo**              : If you have rust installed just run `cargo install --git https://github.com/blightmud/blightmud blightmud` from your favourite terminal.
 - **Other/Alternative**  : Download source and run `cargo install --path .` from the project root
 - **Windows**            : No native windows support but Blightmud runs fine under WSL
+- **Android**            : Can run in [Termux](https://termux.dev/) by compiling from source
 
 ## Compiling
 
@@ -80,6 +81,7 @@ me to the word **blight** and here we are.
 Dependencies include, openssl, alsa-libs and pkg-config
 - Ubuntu    `apt install pkg-config libopenssl-dev libasound2-dev libclang-dev`
 - Arch      `pacman -S pkgconf alsa-lib openssl clang`
+- Termux    `pkg install pkg-config libgit2 rust`
 
 ### Compile with text-to-speech
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ use net::check_latest_version;
 
 pub const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), env!("GIT_DESCRIBE"));
 pub const PROJECT_NAME: &str = env!("CARGO_PKG_NAME");
+pub const TERMUX_VERSION: Option<&'static str> = option_env!("TERMUX_VERSION");
 
 #[cfg(all(not(test), not(debug_assertions)))]
 const XDG_DATA_DIR: &str = "~/.local/share/blightmud";
@@ -241,10 +242,10 @@ fn run(main_thread_read: Receiver<Event>, mut session: Session, rt: RuntimeConfi
     let help_handler = HelpHandler::new(session.main_writer.clone());
     let mut event_handler = EventHandler::from(&session);
 
-    let mut player = if !rt.integration_test {
-        Player::new()
-    } else {
+    let mut player = if TERMUX_VERSION.is_some() || rt.integration_test {
         Player::disabled()
+    } else {
+        Player::new()
     };
 
     let mut screen: Box<dyn UserInterface> = if !rt.headless_mode {


### PR DESCRIPTION
Blightmud can build in [Termux](https://termux.dev/), but it crashes on startup like so:

<details>
<summary>panic message</summary>

```text
Blightmud crashed !!!

Well this is embarrassing... I guess no software is flawless

Since this is an open source project that values your privacy as a user we don't collect or
automatically submit any information anywhere. It would however be a great help if you took
a minute to submit a bug report on github.

[URL]: https://github.com/blightmud/blightmud/issues
[CRASH_LOG]: /data/data/com.termux/files/usr/tmp/report-a92550cd-dd54-4283-986c-9aa5f40e3523.toml
[ERROR]: panicked at /data/data/com.termux/files/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ndk-context-0.1.1/src/lib.rs:72:30: android context was not initialized

If available, please attach the created crash log to the issue.  Then we'll get around to
fixing your problem as fast as we can.

Br,
Linus Probert and all the contributors
```

</details>

<details>
<summary>crash log</summary>

```text
name = "blightmud"
operating_system = "Android [unknown bitness]"
crate_version = "5.4.0"
explanation = """
Panic occurred in file '/data/data/com.termux/files/home/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ndk-context-0.1.1/src/lib.rs' at line 72
"""
cause = "android context was not initialized"
method = "Panic"
backtrace = """
   0:       0x5a3c3fbc38 - human_panic::report::Report::new::h0c936028cff649b5
   1:       0x5a3c3faf00 - human_panic::handle_dump::h73985c12b9f93452
   2:       0x5a3c2134d0 - blightmud::tools::crash_handler::register_panic_hook::{{closure}}::hcadf38017a350280
   3:       0x5a3c8ca484 - std::panicking::panic_with_hook::h9e0a4c4007676582
   4:       0x5a3c8be5fc - std::panicking::panic_handler::{{closure}}::h2c097d9397118596
   5:       0x5a3c8bd004 - std::sys::backtrace::__rust_end_short_backtrace::h6e663eba0371d0c5
   6:       0x5a3c8c29f4 - __rustc[5a30c7b1d3a14ef]::rust_begin_unwind
   7:       0x5a3c8df964 - core::panicking::panic_fmt::h12d66733910a5e26
   8:       0x5a3c8e3700 - core::option::expect_failed::h108412f1fd711500
   9:       0x5a3c883d4c - ndk_context::android_context::h5ce48fdda9c54425
  10:       0x5a3c872060 - cpal::host::aaudio::android_media::get_min_buffer_size::h6e053ba31cae09b4
  11:       0x5a3c86cfc4 - cpal::host::aaudio::default_supported_configs::h8ff4d004d86f3c09
  12:       0x5a3c86d6c0 - <cpal::host::aaudio::Device as cpal::traits::DeviceTrait>::default_output_config::hdc9668b893fbbd71
  13:       0x5a3c7d56b4 - rodio::stream::OutputStreamBuilder::open_default_stream::h58ff378e68e179d6
  14:       0x5a3c20a910 - blightmud::run::h13acc6d9e82782db
  15:       0x5a3c212da4 - blightmud::start::hda8726624b5ae7e0
  16:       0x5a3c1fcdec - blightmud::main::ha745ec221671a04d
  17:       0x5a3c1fd21c - std::sys::backtrace::__rust_begin_short_backtrace::hec3e92ad7b50ce62
  18:       0x5a3c1fd204 - std::rt::lang_start::{{closure}}::h53d6e29b11fe32c4
  19:       0x5a3c8c4fe4 - std::rt::lang_start_internal::hb15f6d0899ce04ba
  20:       0x5a3c1fd090 - main
  21:       0x797220b604 - __libc_init
"""
```

</details>

I'm guessing the audio subsystem has Android support, but requires initialization. I did find [this function from ndk-context](https://docs.rs/ndk-context/latest/ndk_context/fn.initialize_android_context.html), but I'm not sure how to properly call it in a Termux binary, or if it's even possible.

This PR disables the audio subsystem when building for Termux, which makes it start, and documents how to install and build Blightmud in Termux.