### PR TITLE
Added a .cargo/config.toml per mlua FAQ

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-args=-rdynamic"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-args=-rdynamic"]


### PR DESCRIPTION
I had written an lua module in mlua and tried to load it into blightmud, but I got undefined symbol errors.
Per the mlua FAQ, the application is required to have a .cargo/config with some linker overrides in it, which this PR adds.

[mlua FAQ](https://github.com/mlua-rs/mlua/blob/main/FAQ.md#loading-a-c-module-fails-with-error-undefined-symbol-lua_xxx-how-to-fix)