### PR TITLE
Use TerminalProgram::detect() for markdown rendering capabilities

### DIFF
--- a/src/ui/help_handler.rs
+++ b/src/ui/help_handler.rs
@@ -145,7 +145,7 @@ fn md_settings(syntax_set: &'_ SyntaxSet) -> MDSettings<'_> {
     let terminal_size = TerminalSize::detect().unwrap_or_default();
 
     MDSettings {
-        terminal_capabilities: TerminalProgram::Ansi.capabilities(),
+        terminal_capabilities: TerminalProgram::detect().capabilities(),
         terminal_size,
         theme: Theme::default(),
         syntax_set,


### PR DESCRIPTION
## Summary

- Replace hardcoded `TerminalProgram::Ansi` with `TerminalProgram::detect()` in `md_settings()` for help file markdown rendering
- Allows `pulldown-cmark-mdcat` to detect the actual terminal (Ghostty, Kitty, iTerm2, etc.) and use its full capabilities (e.g. Kitty graphics protocol for images) instead of always falling back to basic ANSI

## Context

`md_settings()` in `src/ui/help_handler.rs` hardcoded `TerminalProgram::Ansi.capabilities()`, which meant the markdown renderer never detected the actual terminal program. While the primary effect is on image rendering capabilities (since all terminal types use the same `StyleCapability::Ansi` for text), this ensures the renderer can take advantage of terminal-specific features when available.

---

**Disclaimer:** This PR was authored with AI assistance. Blightmud is our favorite MUD client — we were exploring SSH client support with it and noticed this while digging through the rendering pipeline. Thanks for building such a great project!