### PR TITLE
Disable broken MudConnection tests from pre-mio API

### DIFF
--- a/src/net/mud_connection.rs
+++ b/src/net/mud_connection.rs
@@ -151,46 +151,6 @@ mod tests {
     }
 
     #[test]
-    fn test_mud_connection_read_not_connected() {
-        let mut conn = MudConnection::new();
-        let mut buf = [0u8; 10];
-        let result = conn.read(&mut buf);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
-    }
-
-    #[test]
-    fn test_mud_connection_write_not_connected() {
-        let mut conn = MudConnection::new();
-        let result = conn.write(b"test");
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
-    }
-
-    #[test]
-    fn test_mud_connection_flush_not_connected() {
-        let mut conn = MudConnection::new();
-        let result = conn.flush();
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_mud_connection_write_all_not_connected() {
-        let mut conn = MudConnection::new();
-        let result = conn.write_all(b"test");
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_mud_connection_clone() {
-        let conn = MudConnection::new();
-        let cloned = conn.clone();
-        assert_eq!(conn.id, cloned.id);
-        assert_eq!(conn.host, cloned.host);
-        assert_eq!(conn.port, cloned.port);
-    }
-
-    #[test]
     fn test_connection_id_increments() {
         let id1 = connection_id();
         let id2 = connection_id();


### PR DESCRIPTION
## Summary

- Remove 5 broken tests in `mud_connection.rs` that reference methods removed in c9f0a45 ("Replace network impl with mio event loop")
- Restores the ability to compile and run `cargo test`

## Problem

After the mio event loop migration in #1333 (commit c9f0a45), five tests in `src/net/mud_connection.rs` reference `read()`, `write()`, `flush()`, `write_all()`, and `clone()` methods that no longer exist on `MudConnection`. Since Rust compiles all test code together, these five broken tests prevent the **entire** test suite from compiling — no tests can run at all.

## Fix

The broken tests are removed. The remaining `test_mud_connection_new`, `test_mud_connection_new_unique_ids`, `test_mud_connection_not_connected`, `test_mud_connection_disconnect_when_not_connected`, and `test_connection_id_increments` tests still compile and pass.

Test suite goes from 0 passing (compile error) to 337 passing.

---

**Disclaimer:** This PR was authored with AI assistance. Blightmud is our favorite MUD client — we were exploring SSH client support with it and noticed the test suite was broken while working on other fixes. Thanks for building such a great project!