### PR TITLE
Adds tag support to lines through lua.

### DIFF
--- a/resources/help/bindings.md
+++ b/resources/help/bindings.md
@@ -105,4 +105,10 @@ blight.bind("up", history.previous_command)
 blight.bind("down", history.next_command)
 blight.bind("ctrl-p", history.previous_command)
 blight.bind("ctrl-n", history.next_command)
+
+-- Toggle tag rendering
+blight.bind("ctrl-t", function()
+    print("Toggling tags")
+    blight.show_tags(not blight.show_tags())
+end)
 ```

--- a/resources/help/blight.md
+++ b/resources/help/blight.md
@@ -158,8 +158,19 @@ Pass `nil` to clear the symbol filter.
 
 ##
 
+***blight.filter_tag_reverse([val]) -> bool***
+Get or set the filter reverse flag. When `false` (default), lines matching the
+filter are hidden. When `true`, lines that do *not* match the filter are hidden
+(i.e. only matching lines are shown). Pass `nil` or omit to get the current
+value without changing it.
+
+- `val`  `true` to reverse filter behavior, `false` to restore default behavior.
+- Returns the current value of the reverse flag.
+
+##
+
 ***blight.filter_tag_reset()***
-Clears all active tag filters.
+Clears all active tag filters, including the reverse flag.
 
 ##
 

--- a/resources/help/blight.md
+++ b/resources/help/blight.md
@@ -134,6 +134,35 @@ end)
 
 ##
 
+***blight.filter_tag_color(color)***
+Filter output lines by tag color. Lines with a matching tag color will be hidden.
+Pass `nil` to clear the color filter.
+
+- `color`  The tag color string to filter on, or `nil` to clear.
+
+##
+
+***blight.filter_tag_key(key)***
+Filter output lines by tag key. Lines with a matching tag key will be hidden.
+Pass `nil` to clear the key filter.
+
+- `key`  The tag key string to filter on, or `nil` to clear.
+
+##
+
+***blight.filter_tag_symbol(symbol)***
+Filter output lines by tag symbol. Lines with a matching tag symbol will be hidden.
+Pass `nil` to clear the symbol filter.
+
+- `symbol`  A single-character string for the tag symbol to filter on, or `nil` to clear.
+
+##
+
+***blight.filter_tag_reset()***
+Clears all active tag filters.
+
+##
+
 ***blight.quit()***
 Exit Blightmud
 

--- a/resources/help/help.md
+++ b/resources/help/help.md
@@ -41,6 +41,7 @@ Available topics:
 - spellcheck
 - status_area
 - storage
+- tags
 - tasks
 - timers
 - trigger

--- a/resources/help/line.md
+++ b/resources/help/line.md
@@ -96,14 +96,14 @@ Possible values are:
 Get or set the ANSI color code used to render this line's tag symbol. When
 there is no color set the tag symbol won't be rendered.
 
-- `color`  An ANSI escape sequence string, e.g. `"\x1b[31m"` for red.
+- `color`  An ANSI escape sequence string, e.g. `"\x1b[31m"` or `C_RED` for red.
 
 ##
 
 ***line:tag_key(string) -> String***
 
-Get or set an arbitrary key associated with this line's tag. Intended for use
-by plugins to identify or group tagged lines.
+Get or set an arbitrary key associated with this line's tag. This can then be
+referenced when filtering the output view on certain tags.
 
 ##
 

--- a/resources/help/line.md
+++ b/resources/help/line.md
@@ -6,45 +6,53 @@ input to the mud or output from it.
 ##
 
 ***line:line() -> String***
+
 Returns the line without escape sequences and color
 
 ##
 
 ***line:raw() -> String***
+
 Returns the complete line as received from the mud.
 
 ##
 
 ***line:gag([val]) -> bool***
+
 Get or set the `gag` flag on this line. The `gag` flag will prevent it from
 being rendered on screen.
 
 ##
 
 ***line:tts_gag([val]) -> bool***
+
 Get or set the `tts_gag` flag on this line. The `tts_gag` flag will prevent it
 from being spoken by TTS.
 
 ##
 
 ***line:tts_interrupt([val]) -> bool***
+
 Get or set the `tts_interrupt` flag on this line. The `tts_interrupt` flag will
 make this line interupt anything currently being spoken by TTS.
 
 ##
 
 ***line:skip_log([val]) -> bool***
+
 Get or set the `skip_log` flag on this line. The `skip_log` will exclude this
 line from the log.
 
 ##
 
 ***line:prompt() -> bool***
+
 Returns if this is a prompt line or not
 
 ##
 
 ***line:replace(string)***
+
 Replaces the content of this line with the provided content.  Repeated calls to
 this method will result in the last calls content becoming the new content for
 the line. This is primarily intended for plugin use and for regular scripting
@@ -55,11 +63,13 @@ utilizing `Line:gag(true)` and `print()` should suffice.
 ##
 
 ***line:replacement() -> String***
+
 Returns the replacement content for this line or nil if nothing has been set.
 
 ##
 
 ***line:matched([val]) -> bool***
+
 Get or set the `matched` flag on this line. The `matched` flag tells if this line
 has been matched by a trigger or not. If you are writing advanced plugins whith
 full output capturing you are responsible for setting this yourself.
@@ -67,6 +77,7 @@ full output capturing you are responsible for setting this yourself.
 ##
 
 ***line:source() -> String***
+
 Return the source of the line.
 
 Primarly used for input handling to differ between user input commands and
@@ -77,3 +88,26 @@ Possible values are:
 - `"user"`    When the line is coming from the users prompt.
 - `"script"`  When the line is sent to the mud from a lua script.
 - `nil`       When the line comes from neither of the above.
+
+##
+
+***line:tag_color(string) -> String***
+
+Get or set the ANSI color code used to render this line's tag symbol. When
+there is no color set the tag symbol won't be rendered.
+
+- `color`  An ANSI escape sequence string, e.g. `"\x1b[31m"` for red.
+
+##
+
+***line:tag_key(string) -> String***
+
+Get or set an arbitrary key associated with this line's tag. Intended for use
+by plugins to identify or group tagged lines.
+
+##
+
+***line:tag_symbol(char) -> String***
+
+Get or set the character used as the tag symbol. Defaults to `┃` (U+2503,
+BOX DRAWINGS HEAVY VERTICAL). Only rendered when a tag color is set.

--- a/resources/help/tags.md
+++ b/resources/help/tags.md
@@ -43,7 +43,7 @@ BOX DRAWINGS HEAVY VERTICAL). Only rendered when a tag color is set.
 ***line:tag_key(key) -> string***
 
 Get or set an arbitrary string key associated with this line's tag. Useful for
-plugins to identify or group tagged lines.
+filtering lines.
 
 ### Example
 
@@ -76,7 +76,7 @@ Hide lines whose tag key equals `key`. Pass `nil` to clear.
 ***blight.filter_tag_symbol(symbol)***
 Hide lines whose tag symbol equals `symbol`. Pass `nil` to clear.
 
-***blight.filter_tag_reverse([val]) -> bool***
+***blight.filter_tag_reverse(val) -> bool***
 Get or set the reverse flag. When `false` (default), matching lines are hidden.
 When `true`, non-matching lines are hidden — only lines that match the filter
 are shown. Pass no argument to get the current value without changing it.

--- a/resources/help/tags.md
+++ b/resources/help/tags.md
@@ -1,0 +1,109 @@
+# Tags
+
+Tags are visual markers that can be attached to output lines. When tag rendering
+is enabled, each line is prefixed with a colored symbol (or two plain spaces if
+the line has no tag color set). Tags can be used to visually group, highlight,
+or filter lines in the output view.
+
+## Enabling tag rendering
+
+Tag rendering is off by default. Enable it with `blight.show_tags()`:
+
+```lua
+blight.show_tags(true)   -- enable
+blight.show_tags(false)  -- disable
+blight.show_tags()       -- returns current state (bool)
+```
+
+A convenient keybinding to toggle tags (default):
+
+```lua
+blight.bind("ctrl-t", function()
+    blight.show_tags(not blight.show_tags())
+end)
+```
+
+## Setting tags on lines
+
+Tags are set on `Line` objects, typically inside a trigger callback. Three
+properties make up a tag:
+
+***line:tag_color(color) -> string***
+
+Get or set the ANSI color used to render the tag symbol. Setting a color
+activates the tag. When no color is set the tag symbol is not rendered.
+
+- `color`  An ANSI escape sequence, e.g. `"\x1b[31m"` or a constant `C_RED`.
+
+***line:tag_symbol(char) -> string***
+
+Get or set the character used as the tag symbol. Defaults to `┃` (U+2503,
+BOX DRAWINGS HEAVY VERTICAL). Only rendered when a tag color is set.
+
+***line:tag_key(key) -> string***
+
+Get or set an arbitrary string key associated with this line's tag. Useful for
+plugins to identify or group tagged lines.
+
+### Example
+
+```lua
+trigger.add("^You receive", {}, function (_, line)
+    line:tag_color(C_GREEN)
+    line:tag_symbol("$")
+    line:tag_key("income")
+end)
+
+trigger.add("^You spend", {}, function (_, line)
+    line:tag_color(C_RED)
+    line:tag_symbol("$")
+    line:tag_key("expense")
+end)
+```
+
+## Filtering lines by tag
+
+Tag filters hide lines whose tag matches the given value. Filters apply to
+existing lines in the view as well as new ones. Multiple filters can be active
+simultaneously — a line is hidden if *any* filter matches it.
+
+***blight.filter_tag_color(color)***
+Hide lines whose tag color equals `color`. Pass `nil` to clear.
+
+***blight.filter_tag_key(key)***
+Hide lines whose tag key equals `key`. Pass `nil` to clear.
+
+***blight.filter_tag_symbol(symbol)***
+Hide lines whose tag symbol equals `symbol`. Pass `nil` to clear.
+
+***blight.filter_tag_reverse([val]) -> bool***
+Get or set the reverse flag. When `false` (default), matching lines are hidden.
+When `true`, non-matching lines are hidden — only lines that match the filter
+are shown. Pass no argument to get the current value without changing it.
+
+***blight.filter_tag_reset()***
+Clear all active tag filters, including the reverse flag.
+
+### Example
+
+```lua
+-- Hide all income lines
+blight.filter_tag_key("income")
+
+-- Show them again
+blight.filter_tag_key(nil)
+
+-- Show ONLY combat lines (hide everything else)
+blight.filter_tag_key("combat")
+blight.filter_tag_reverse(true)
+
+-- Back to normal
+blight.filter_tag_reset()
+```
+
+## See also
+
+- `/help line`      — Full Line object reference
+- `/help blight`    — Full blight module reference
+- `/help bindings`  — Keybinding examples
+- `/help colors`    — Available color constants

--- a/resources/lua/bindings.lua
+++ b/resources/lua/bindings.lua
@@ -41,3 +41,8 @@ blight.bind("up", history.previous_command)
 blight.bind("down", history.next_command)
 blight.bind("ctrl-p", history.previous_command)
 blight.bind("ctrl-n", history.next_command)
+
+-- Toggle tag rendering
+blight.bind("ctrl-t", function()
+    blight.show_tags(not blight.show_tags())
+end)

--- a/resources/lua/types/blightmud.d.lua
+++ b/resources/lua/types/blightmud.d.lua
@@ -298,7 +298,14 @@ function BlightLib.filter_tag_key(key) end
 ---@param symbol? string
 function BlightLib.filter_tag_symbol(symbol) end
 
----Clears all active tag filters.
+---Gets or sets the filter reverse flag. When false (default), matching lines are
+---hidden. When true, non-matching lines are hidden (only matching lines shown).
+---Pass nil or omit to get the current value without changing it.
+---@param val? boolean
+---@return boolean
+function BlightLib.filter_tag_reverse(val) end
+
+---Clears all active tag filters, including the reverse flag.
 function BlightLib.filter_tag_reset() end
 
 ---Returns the application name and version as two separate values.

--- a/resources/lua/types/blightmud.d.lua
+++ b/resources/lua/types/blightmud.d.lua
@@ -58,6 +58,24 @@ function Line:source() end
 ---@return string|nil
 function Line:replacement() end
 
+---Gets or sets the ANSI color code used to render this line's tag symbol.
+---When set, the tag symbol and a trailing space are rendered in that color before the line content.
+---When empty, two plain spaces are rendered instead.
+---@param color? string ANSI escape sequence, e.g. `"\x1b[31m"` for red.
+---@return string
+function Line:tag_color(color) end
+
+---Gets or sets an arbitrary key associated with this line's tag.
+---@param key? string
+---@return string
+function Line:tag_key(key) end
+
+---Gets or sets the character used as the tag symbol. Defaults to `┃` (U+2503).
+---Only rendered when a tag color is set.
+---@param symbol? string
+---@return string
+function Line:tag_symbol(symbol) end
+
 --------------------------------------------------------------------------------
 -- Regex -----------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -257,6 +275,13 @@ function BlightLib.status_height(height) end
 ---@param index integer  0-based line index.
 ---@param line string
 function BlightLib.status_line(index, line) end
+
+---Gets or sets whether tag rendering is enabled. When enabled, each output
+---line is prefixed with the line's tag symbol and color (or two spaces if no
+---color is set). Defaults to false. Returns the current value.
+---@param show? boolean
+---@return boolean
+function BlightLib.show_tags(show) end
 
 ---Returns the application name and version as two separate values.
 ---@return string, string

--- a/resources/lua/types/blightmud.d.lua
+++ b/resources/lua/types/blightmud.d.lua
@@ -283,6 +283,24 @@ function BlightLib.status_line(index, line) end
 ---@return boolean
 function BlightLib.show_tags(show) end
 
+---Filters output lines by tag color. Lines whose tag color matches will be hidden.
+---Pass nil to clear the color filter.
+---@param color? string
+function BlightLib.filter_tag_color(color) end
+
+---Filters output lines by tag key. Lines whose tag key matches will be hidden.
+---Pass nil to clear the key filter.
+---@param key? string
+function BlightLib.filter_tag_key(key) end
+
+---Filters output lines by tag symbol. Lines whose tag symbol matches will be hidden.
+---Pass nil to clear the symbol filter.
+---@param symbol? string
+function BlightLib.filter_tag_symbol(symbol) end
+
+---Clears all active tag filters.
+function BlightLib.filter_tag_reset() end
+
 ---Returns the application name and version as two separate values.
 ---@return string, string
 function BlightLib.version() end

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,7 +3,7 @@ use crate::lua::ConnectionInfo;
 use crate::net::spawn_connect_thread;
 use crate::{audio::SourceOptions, model::Regex};
 use crate::{
-    model::{Connection, Line, PromptMask},
+    model::{Connection, Line, PromptMask, TagMask},
     net::{spawn_network_thread, WakingSender},
     session::Session,
     tts::TTSEvent,
@@ -88,6 +88,7 @@ pub enum Event {
     SetPromptCursorPos(usize),
     SetPromptMask(PromptMask),
     ClearPromptMask,
+    SetTagMask(TagMask),
     UserInputBuffer(String, usize),
     UserInputCursor(usize),
     FSEvent(FSEvent),

--- a/src/event.rs
+++ b/src/event.rs
@@ -71,6 +71,7 @@ pub enum Event {
     ServerSend(Bytes),
     SettingChanged(String, bool),
     ShowHelp(String, bool),
+    ShowTags(bool),
     Speak(String, bool),
     SpeakStop,
     StartLogging(String, bool),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,6 +488,7 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
             }
             Event::StatusAreaHeight(height) => screen.set_status_area_height(height)?,
             Event::ShowTags(show) => screen.set_show_tags(show)?,
+            Event::SetTagMask(mask) => screen.set_tag_mask(mask),
             Event::StatusLine(index, info) => screen.set_status_line(index, info)?,
             Event::LoadScript(path) => {
                 info!("Loading script: {}", path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,6 +487,7 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
                 event_handler.handle_scroll_events(event, &mut screen)?;
             }
             Event::StatusAreaHeight(height) => screen.set_status_area_height(height)?,
+            Event::ShowTags(show) => screen.set_show_tags(show)?,
             Event::StatusLine(index, info) => screen.set_status_line(index, info)?,
             Event::LoadScript(path) => {
                 info!("Loading script: {}", path);

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -2,6 +2,7 @@ use super::{constants::*, regex::Regex, ui_event::UiEvent};
 use crate::event::{Event, QuitMethod};
 use crate::{
     model::{Line, TagMask},
+    tools::printable_chars::PrintableCharsIterator,
     PROJECT_NAME, VERSION,
 };
 use log::debug;
@@ -195,7 +196,7 @@ impl UserData for Blight {
         methods.add_function("filter_tag_color", |ctx, color: Option<String>| {
             let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
             let mut this = this_aux.borrow_mut::<Blight>()?;
-            this.tag_mask.color = color;
+            this.tag_mask.color = color.filter(|c| c.as_str().display_width() == 0);
             this.main_writer
                 .send(Event::SetTagMask(this.tag_mask.clone()))
                 .unwrap();

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -1,6 +1,9 @@
 use super::{constants::*, regex::Regex, ui_event::UiEvent};
 use crate::event::{Event, QuitMethod};
-use crate::{model::Line, PROJECT_NAME, VERSION};
+use crate::{
+    model::{Line, TagMask},
+    PROJECT_NAME, VERSION,
+};
 use log::debug;
 use mlua::{
     AnyUserData, FromLua, Function, Result as LuaResult, Table, UserData, UserDataMethods, Variadic,
@@ -16,6 +19,7 @@ pub struct Blight {
     pub core_mode: bool,
     pub reader_mode: bool,
     pub _tts_enabled: bool,
+    tag_mask: TagMask,
 }
 
 impl Blight {
@@ -28,6 +32,7 @@ impl Blight {
             core_mode: false,
             reader_mode: false,
             _tts_enabled: false,
+            tag_mask: TagMask::default(),
         }
     }
 
@@ -187,6 +192,42 @@ impl UserData for Blight {
                 Ok(ctx.named_registry_value(SHOW_TAGS).unwrap_or(false))
             },
         );
+        methods.add_function("filter_tag_color", |ctx, color: Option<String>| {
+            let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
+            let mut this = this_aux.borrow_mut::<Blight>()?;
+            this.tag_mask.color = color;
+            this.main_writer
+                .send(Event::SetTagMask(this.tag_mask.clone()))
+                .unwrap();
+            Ok(())
+        });
+        methods.add_function("filter_tag_key", |ctx, key: Option<String>| {
+            let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
+            let mut this = this_aux.borrow_mut::<Blight>()?;
+            this.tag_mask.key = key;
+            this.main_writer
+                .send(Event::SetTagMask(this.tag_mask.clone()))
+                .unwrap();
+            Ok(())
+        });
+        methods.add_function("filter_tag_symbol", |ctx, symbol: Option<String>| {
+            let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
+            let mut this = this_aux.borrow_mut::<Blight>()?;
+            this.tag_mask.symbol = symbol.and_then(|s| s.chars().next());
+            this.main_writer
+                .send(Event::SetTagMask(this.tag_mask.clone()))
+                .unwrap();
+            Ok(())
+        });
+        methods.add_function("filter_tag_reset", |ctx, ()| {
+            let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
+            let mut this = this_aux.borrow_mut::<Blight>()?;
+            this.tag_mask = TagMask::default();
+            this.main_writer
+                .send(Event::SetTagMask(this.tag_mask.clone()))
+                .unwrap();
+            Ok(())
+        });
         methods.add_function("find_backward", |ctx, re: Regex| {
             let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
             let this = this_aux.borrow::<Blight>()?;

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -219,6 +219,17 @@ impl UserData for Blight {
                 .unwrap();
             Ok(())
         });
+        methods.add_function("filter_tag_reverse", |ctx, val: Option<bool>| {
+            let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
+            let mut this = this_aux.borrow_mut::<Blight>()?;
+            if let Some(val) = val {
+                this.tag_mask.reverse = val;
+                this.main_writer
+                    .send(Event::SetTagMask(this.tag_mask.clone()))
+                    .unwrap();
+            }
+            Ok(this.tag_mask.reverse)
+        });
         methods.add_function("filter_tag_reset", |ctx, ()| {
             let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
             let mut this = this_aux.borrow_mut::<Blight>()?;
@@ -484,6 +495,43 @@ mod test_blight {
         // Set back to false
         lua.load("blight.show_tags(false)").exec().unwrap();
         assert_eq!(reader.recv(), Ok(Event::ShowTags(false)));
+    }
+
+    #[test]
+    fn test_filter_tag_reverse() {
+        let (lua, reader) = get_lua_state();
+
+        // Default is false
+        let val = lua
+            .load("return blight.filter_tag_reverse()")
+            .call::<bool>(())
+            .unwrap();
+        assert!(!val);
+
+        // Set to true
+        let val = lua
+            .load("return blight.filter_tag_reverse(true)")
+            .call::<bool>(())
+            .unwrap();
+        assert!(val);
+        // Discard the SetTagMask event
+        let _ = reader.recv();
+
+        // Getter reflects update
+        let val = lua
+            .load("return blight.filter_tag_reverse()")
+            .call::<bool>(())
+            .unwrap();
+        assert!(val);
+
+        // Reset clears reverse too
+        lua.load("blight.filter_tag_reset()").exec().unwrap();
+        let _ = reader.recv();
+        let val = lua
+            .load("return blight.filter_tag_reverse()")
+            .call::<bool>(())
+            .unwrap();
+        assert!(!val);
     }
 
     #[test]

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -175,6 +175,18 @@ impl UserData for Blight {
                 .unwrap();
             Ok(())
         });
+        methods.add_function(
+            "show_tags",
+            |ctx, val: Option<bool>| -> mlua::Result<bool> {
+                if let Some(val) = val {
+                    let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
+                    let this = this_aux.borrow::<Blight>()?;
+                    this.main_writer.send(Event::ShowTags(val)).unwrap();
+                    ctx.set_named_registry_value(SHOW_TAGS, val)?;
+                }
+                Ok(ctx.named_registry_value(SHOW_TAGS).unwrap_or(false))
+            },
+        );
         methods.add_function("find_backward", |ctx, re: Regex| {
             let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
             let this = this_aux.borrow::<Blight>()?;
@@ -204,7 +216,7 @@ mod test_blight {
     use super::Blight;
     use crate::lua::constants::{
         BLIGHT_ON_DIMENSIONS_CHANGE_LISTENER_TABLE, BLIGHT_ON_QUIT_LISTENER_TABLE,
-        COMMAND_BINDING_TABLE, COMPLETION_CALLBACK_TABLE, STATUS_AREA_HEIGHT,
+        COMMAND_BINDING_TABLE, COMPLETION_CALLBACK_TABLE, SHOW_TAGS, STATUS_AREA_HEIGHT,
     };
     use crate::{PROJECT_NAME, VERSION};
 
@@ -228,6 +240,7 @@ mod test_blight {
             .unwrap();
         lua.set_named_registry_value(STATUS_AREA_HEIGHT, 1u16)
             .unwrap();
+        lua.set_named_registry_value(SHOW_TAGS, false).unwrap();
         (lua, reader)
     }
 
@@ -399,6 +412,37 @@ mod test_blight {
         let bindings: mlua::Table = lua.named_registry_value(COMMAND_BINDING_TABLE).unwrap();
         assert!(bindings.get::<mlua::Function>("alt-H").is_ok());
         assert!(bindings.get::<mlua::Function>("alt-h").is_err());
+    }
+
+    #[test]
+    fn test_show_tags() {
+        let (lua, reader) = get_lua_state();
+
+        // Default is false
+        let val = lua
+            .load("return blight.show_tags()")
+            .call::<bool>(())
+            .unwrap();
+        assert!(!val);
+
+        // Set to true
+        let val = lua
+            .load("return blight.show_tags(true)")
+            .call::<bool>(())
+            .unwrap();
+        assert!(val);
+        assert_eq!(reader.recv(), Ok(Event::ShowTags(true)));
+
+        // Getter reflects update
+        let val = lua
+            .load("return blight.show_tags()")
+            .call::<bool>(())
+            .unwrap();
+        assert!(val);
+
+        // Set back to false
+        lua.load("blight.show_tags(false)").exec().unwrap();
+        assert_eq!(reader.recv(), Ok(Event::ShowTags(false)));
     }
 
     #[test]

--- a/src/lua/constants.rs
+++ b/src/lua/constants.rs
@@ -21,6 +21,7 @@ pub const PROMPT_INPUT_LISTENER_TABLE: &str = "__prompt_listeners";
 pub const FS_LISTENERS: &str = "__fs_listeners";
 pub const SCRIPT_RESET_LISTENERS: &str = "__script_reset_listeners";
 pub const STATUS_AREA_HEIGHT: &str = "__status_area_height";
+pub const SHOW_TAGS: &str = "__show_tags";
 
 // Core tables
 pub const PROTO_ENABLED_LISTENERS_TABLE: &str = "__protocol_enabled_listeners";

--- a/src/lua/line.rs
+++ b/src/lua/line.rs
@@ -1,6 +1,8 @@
+use log::warn;
 use mlua::{FromLua, UserData, UserDataMethods};
 
 use crate::model::Line as mLine;
+use crate::tools::printable_chars::PrintableCharsIterator;
 
 #[derive(Clone, FromLua)]
 pub struct Line {
@@ -35,7 +37,11 @@ impl UserData for Line {
             "tag_color",
             |_, this, color: Option<String>| -> mlua::Result<String> {
                 if let Some(color) = color {
-                    this.inner.tag.color = color;
+                    if color.as_str().display_width() == 0 {
+                        this.inner.tag.color = color;
+                    } else {
+                        warn!("Invalid ANSI color provided for tag: {color}");
+                    }
                 }
                 Ok(this.inner.tag.color.clone())
             },
@@ -278,11 +284,22 @@ mod test_lua_line {
         test_lua!("test_line" => test_line());
 
         assert_lua_string!("test_line:tag_color()", "");
-        run_lua!("test_line:tag_color('red')");
-        assert_lua_string!("test_line:tag_color()", "red");
+        run_lua!("test_line:tag_color('\x1b[31m')");
+        assert_lua_string!("test_line:tag_color()", "\x1b[31m");
 
         let line: Line = global!("test_line");
-        assert_eq!(line.inner.tag.color, "red");
+        assert_eq!(line.inner.tag.color, "\x1b[31m");
+    }
+
+    #[test]
+    fn test_tag_color_rejects_printable_strings() {
+        test_lua!("test_line" => test_line());
+
+        run_lua!("test_line:tag_color('red')");
+        assert_lua_string!("test_line:tag_color()", "");
+
+        let line: Line = global!("test_line");
+        assert_eq!(line.inner.tag.color, "");
     }
 
     #[test]
@@ -301,11 +318,11 @@ mod test_lua_line {
     fn test_tag_color_does_not_affect_key() {
         test_lua!("test_line" => test_line());
 
-        run_lua!("test_line:tag_color('blue')");
+        run_lua!("test_line:tag_color('\x1b[34m')");
         run_lua!("test_line:tag_key('k')");
 
         let line: Line = global!("test_line");
-        assert_eq!(line.inner.tag.color, "blue");
+        assert_eq!(line.inner.tag.color, "\x1b[34m");
         assert_eq!(line.inner.tag.key, "k");
     }
 

--- a/src/lua/line.rs
+++ b/src/lua/line.rs
@@ -32,6 +32,33 @@ impl UserData for Line {
             Ok(this.inner.flags.gag)
         });
         methods.add_method_mut(
+            "tag_color",
+            |_, this, color: Option<String>| -> mlua::Result<String> {
+                if let Some(color) = color {
+                    this.inner.tag.color = color;
+                }
+                Ok(this.inner.tag.color.clone())
+            },
+        );
+        methods.add_method_mut(
+            "tag_key",
+            |_, this, key: Option<String>| -> mlua::Result<String> {
+                if let Some(key) = key {
+                    this.inner.tag.key = key;
+                }
+                Ok(this.inner.tag.key.clone())
+            },
+        );
+        methods.add_method_mut(
+            "tag_symbol",
+            |_, this, sym: Option<char>| -> mlua::Result<char> {
+                if let Some(sym) = sym {
+                    this.inner.tag.symbol = sym;
+                }
+                Ok(this.inner.tag.symbol)
+            },
+        );
+        methods.add_method_mut(
             "tts_gag",
             |_, this, gag: Option<bool>| -> mlua::Result<bool> {
                 if let Some(gag) = gag {
@@ -244,6 +271,54 @@ mod test_lua_line {
         assert_lua_bool!("test_line:matched()", true);
         run_lua!("test_line:matched(false)");
         assert_lua_bool!("test_line:matched()", false);
+    }
+
+    #[test]
+    fn test_tag_color() {
+        test_lua!("test_line" => test_line());
+
+        assert_lua_string!("test_line:tag_color()", "");
+        run_lua!("test_line:tag_color('red')");
+        assert_lua_string!("test_line:tag_color()", "red");
+
+        let line: Line = global!("test_line");
+        assert_eq!(line.inner.tag.color, "red");
+    }
+
+    #[test]
+    fn test_tag_key() {
+        test_lua!("test_line" => test_line());
+
+        assert_lua_string!("test_line:tag_key()", "");
+        run_lua!("test_line:tag_key('mykey')");
+        assert_lua_string!("test_line:tag_key()", "mykey");
+
+        let line: Line = global!("test_line");
+        assert_eq!(line.inner.tag.key, "mykey");
+    }
+
+    #[test]
+    fn test_tag_color_does_not_affect_key() {
+        test_lua!("test_line" => test_line());
+
+        run_lua!("test_line:tag_color('blue')");
+        run_lua!("test_line:tag_key('k')");
+
+        let line: Line = global!("test_line");
+        assert_eq!(line.inner.tag.color, "blue");
+        assert_eq!(line.inner.tag.key, "k");
+    }
+
+    #[test]
+    fn test_tag_symbol() {
+        test_lua!("test_line" => test_line());
+
+        assert_lua_string!("test_line:tag_symbol()", "┃");
+        run_lua!("test_line:tag_symbol('!')");
+        assert_lua_string!("test_line:tag_symbol()", "!");
+
+        let line: Line = global!("test_line");
+        assert_eq!(line.inner.tag.symbol, '!');
     }
 
     #[test]

--- a/src/model/line.rs
+++ b/src/model/line.rs
@@ -1,6 +1,7 @@
 use log::error;
 use std::fmt;
 use strip_ansi_escapes::strip as strip_ansi;
+use unicode_width::UnicodeWidthChar;
 
 pub trait ToLine {
     fn to_line(&self) -> Line;
@@ -323,6 +324,8 @@ impl Line {
         self.print_line().map(|content| {
             if self.tag.color.is_empty() {
                 format!("  {}", content)
+            } else if self.tag.symbol.width() == Some(2) {
+                format!("{}{}\x1b[0m{}", self.tag.color, self.tag.symbol, content)
             } else {
                 format!("{}{} \x1b[0m{}", self.tag.color, self.tag.symbol, content)
             }

--- a/src/model/line.rs
+++ b/src/model/line.rs
@@ -26,6 +26,13 @@ pub struct Tag {
     pub color: String,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TagMask {
+    pub symbol: Option<char>,
+    pub key: Option<String>,
+    pub color: Option<String>,
+}
+
 impl Default for Tag {
     fn default() -> Self {
         Self {
@@ -78,6 +85,18 @@ impl Line {
             line.as_bytes().into()
         } else {
             raw.into()
+        }
+    }
+
+    pub fn is_masked(&self, mask: &TagMask) -> bool {
+        if let Some(color) = &mask.color {
+            self.tag.color == *color
+        } else if let Some(key) = &mask.key {
+            self.tag.key == *key
+        } else if let Some(symbol) = mask.symbol {
+            self.tag.symbol == symbol
+        } else {
+            false
         }
     }
 }
@@ -536,5 +555,70 @@ mod test_line {
         let mut line = Line::from("hello");
         line.flags.gag = true;
         assert_eq!(line.tagged_line(), None);
+    }
+
+    #[test]
+    fn test_is_masked_empty_mask() {
+        let line = Line::from("hello");
+        let mask = super::TagMask::default();
+        assert!(!line.is_masked(&mask));
+    }
+
+    #[test]
+    fn test_is_masked_by_key() {
+        let mut line = Line::from("hello");
+        line.tag.key = "combat".to_string();
+        let mask = super::TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        assert!(line.is_masked(&mask));
+    }
+
+    #[test]
+    fn test_is_masked_by_key_no_match() {
+        let mut line = Line::from("hello");
+        line.tag.key = "combat".to_string();
+        let mask = super::TagMask {
+            key: Some("loot".to_string()),
+            ..Default::default()
+        };
+        assert!(!line.is_masked(&mask));
+    }
+
+    #[test]
+    fn test_is_masked_by_color() {
+        let mut line = Line::from("hello");
+        line.tag.color = "\x1b[31m".to_string();
+        let mask = super::TagMask {
+            color: Some("\x1b[31m".to_string()),
+            ..Default::default()
+        };
+        assert!(line.is_masked(&mask));
+    }
+
+    #[test]
+    fn test_is_masked_by_symbol() {
+        let mut line = Line::from("hello");
+        line.tag.symbol = '!';
+        let mask = super::TagMask {
+            symbol: Some('!'),
+            ..Default::default()
+        };
+        assert!(line.is_masked(&mask));
+    }
+
+    #[test]
+    fn test_is_masked_color_takes_priority_over_key() {
+        // When color is set in mask, key is not checked
+        let mut line = Line::from("hello");
+        line.tag.color = "\x1b[32m".to_string();
+        line.tag.key = "combat".to_string();
+        let mask = super::TagMask {
+            color: Some("\x1b[31m".to_string()), // different color — no match
+            key: Some("combat".to_string()),     // key would match, but color is checked first
+            ..Default::default()
+        };
+        assert!(!line.is_masked(&mask));
     }
 }

--- a/src/model/line.rs
+++ b/src/model/line.rs
@@ -2,6 +2,23 @@ use log::error;
 use std::fmt;
 use strip_ansi_escapes::strip as strip_ansi;
 
+pub trait ToLine {
+    fn to_line(&self) -> Line;
+    fn to_internal_line(&self) -> Line;
+}
+
+impl ToLine for str {
+    fn to_line(&self) -> Line {
+        Line::from(self)
+    }
+
+    fn to_internal_line(&self) -> Line {
+        let mut line = self.to_line();
+        line.tag.key = "internal".to_string();
+        line
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Tag {
     pub symbol: char,

--- a/src/model/line.rs
+++ b/src/model/line.rs
@@ -358,6 +358,7 @@ impl Line {
 
     pub fn replace_with(&mut self, other: &Line) {
         self.flags = other.flags.clone();
+        self.tag = other.tag.clone();
     }
 }
 

--- a/src/model/line.rs
+++ b/src/model/line.rs
@@ -2,6 +2,23 @@ use log::error;
 use std::fmt;
 use strip_ansi_escapes::strip as strip_ansi;
 
+#[derive(Debug, Clone)]
+pub struct Tag {
+    pub symbol: char,
+    pub key: String,
+    pub color: String,
+}
+
+impl Default for Tag {
+    fn default() -> Self {
+        Self {
+            symbol: '┃',
+            key: String::new(),
+            color: String::new(),
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Flags {
     pub gag: bool,
@@ -24,6 +41,7 @@ pub struct Line {
     content: String,
     clean_content: String,
     clean_utf8: bool,
+    pub tag: Tag,
     pub flags: Flags,
 }
 
@@ -140,6 +158,7 @@ impl From<&Line> for Line {
             content: line.content.clone(),
             clean_content: line.clean_content.clone(),
             clean_utf8: line.clean_utf8,
+            tag: line.tag.clone(),
             flags: line.flags.clone(),
         }
     }
@@ -152,6 +171,7 @@ impl From<&str> for Line {
             content,
             clean_content,
             clean_utf8,
+            tag: Tag::default(),
             flags: Flags {
                 screen_clear,
                 ..Flags::default()
@@ -167,6 +187,7 @@ impl From<String> for Line {
             content,
             clean_content,
             clean_utf8,
+            tag: Tag::default(),
             flags: Flags {
                 screen_clear,
                 ..Flags::default()
@@ -182,6 +203,7 @@ impl From<&String> for Line {
             content,
             clean_content,
             clean_utf8,
+            tag: Tag::default(),
             flags: Flags {
                 screen_clear,
                 ..Flags::default()
@@ -204,6 +226,7 @@ impl From<&[u8]> for Line {
             content,
             clean_content,
             clean_utf8,
+            tag: Tag::default(),
             flags: Flags {
                 screen_clear,
                 ..Flags::default()
@@ -227,6 +250,7 @@ impl From<&Vec<u8>> for Line {
             content,
             clean_content,
             clean_utf8,
+            tag: Tag::default(),
             flags: Flags {
                 screen_clear,
                 ..Flags::default()
@@ -251,6 +275,16 @@ impl Line {
         } else {
             None
         }
+    }
+
+    pub fn tagged_line(&self) -> Option<String> {
+        self.print_line().map(|content| {
+            if self.tag.color.is_empty() {
+                format!("  {}", content)
+            } else {
+                format!("{}{} \x1b[0m{}", self.tag.color, self.tag.symbol, content)
+            }
+        })
     }
 
     pub fn is_utf8(&self) -> bool {
@@ -461,5 +495,29 @@ mod test_line {
         let line = Line::from("\x1b[2J\x1b[J\x1b[1J");
         assert_eq!(line.line(), "");
         assert!(line.flags.screen_clear);
+    }
+
+    #[test]
+    fn test_tagged_line_default() {
+        let line = Line::from("hello");
+        // Default tag has no color: render two spaces
+        assert_eq!(line.tagged_line(), Some("  hello".to_string()));
+    }
+
+    #[test]
+    fn test_tagged_line_with_color() {
+        let mut line = Line::from("hello");
+        line.tag.color = "\x1b[31m".to_string();
+        assert_eq!(
+            line.tagged_line(),
+            Some("\x1b[31m┃ \x1b[0mhello".to_string())
+        );
+    }
+
+    #[test]
+    fn test_tagged_line_gagged() {
+        let mut line = Line::from("hello");
+        line.flags.gag = true;
+        assert_eq!(line.tagged_line(), None);
     }
 }

--- a/src/model/line.rs
+++ b/src/model/line.rs
@@ -31,6 +31,7 @@ pub struct TagMask {
     pub symbol: Option<char>,
     pub key: Option<String>,
     pub color: Option<String>,
+    pub reverse: bool,
 }
 
 impl Default for Tag {
@@ -89,14 +90,19 @@ impl Line {
     }
 
     pub fn is_masked(&self, mask: &TagMask) -> bool {
-        if let Some(color) = &mask.color {
+        let matched = if let Some(color) = &mask.color {
             self.tag.color == *color
         } else if let Some(key) = &mask.key {
             self.tag.key == *key
         } else if let Some(symbol) = mask.symbol {
             self.tag.symbol == symbol
         } else {
-            false
+            return false;
+        };
+        if mask.reverse {
+            !matched
+        } else {
+            matched
         }
     }
 }
@@ -618,6 +624,43 @@ mod test_line {
         let mask = super::TagMask {
             color: Some("\x1b[31m".to_string()), // different color — no match
             key: Some("combat".to_string()),     // key would match, but color is checked first
+            ..Default::default()
+        };
+        assert!(!line.is_masked(&mask));
+    }
+
+    #[test]
+    fn test_is_masked_reverse_match_not_masked() {
+        // reverse: true — a matching line is NOT masked (it passes through)
+        let mut line = Line::from("hello");
+        line.tag.key = "combat".to_string();
+        let mask = super::TagMask {
+            key: Some("combat".to_string()),
+            reverse: true,
+            ..Default::default()
+        };
+        assert!(!line.is_masked(&mask));
+    }
+
+    #[test]
+    fn test_is_masked_reverse_no_match_is_masked() {
+        // reverse: true — a non-matching line IS masked (hidden)
+        let mut line = Line::from("hello");
+        line.tag.key = "loot".to_string();
+        let mask = super::TagMask {
+            key: Some("combat".to_string()),
+            reverse: true,
+            ..Default::default()
+        };
+        assert!(line.is_masked(&mask));
+    }
+
+    #[test]
+    fn test_is_masked_reverse_empty_mask_never_masks() {
+        // reverse: true with no criteria — still never masks anything
+        let line = Line::from("hello");
+        let mask = super::TagMask {
+            reverse: true,
             ..Default::default()
         };
         assert!(!line.is_masked(&mask));

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -8,6 +8,6 @@ mod settings;
 pub use self::{regex::Regex, regex::RegexOptions};
 pub use completions::Completions;
 pub use connection::{Connection, Servers};
-pub use line::Line;
+pub use line::{Line, ToLine};
 pub use prompt_mask::PromptMask;
 pub use settings::*;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -8,6 +8,6 @@ mod settings;
 pub use self::{regex::Regex, regex::RegexOptions};
 pub use completions::Completions;
 pub use connection::{Connection, Servers};
-pub use line::{Line, ToLine};
+pub use line::{Line, TagMask, ToLine};
 pub use prompt_mask::PromptMask;
 pub use settings::*;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,5 +1,6 @@
 mod crash_handler;
 pub mod patch;
+pub mod printable_chars;
 pub mod util;
 
 pub use self::crash_handler::register_panic_hook;

--- a/src/tools/printable_chars.rs
+++ b/src/tools/printable_chars.rs
@@ -139,7 +139,7 @@ impl<'a> Iterator for PrintableCharIndices<'a> {
 
 #[cfg(test)]
 mod test_printable_chars {
-    use crate::ui::printable_chars::PrintableCharsIterator;
+    use crate::tools::printable_chars::PrintableCharsIterator;
 
     const ANSI_RED: &str = "\x1b[30m";
     const ANSI_OFF: &str = "\x1b[0m";

--- a/src/ui/headless_screen.rs
+++ b/src/ui/headless_screen.rs
@@ -96,6 +96,10 @@ impl UserInterface for HeadlessScreen {
         Ok(())
     }
 
+    fn set_show_tags(&mut self, _show: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     fn set_status_line(&mut self, _line: usize, _info: String) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/ui/headless_screen.rs
+++ b/src/ui/headless_screen.rs
@@ -100,6 +100,8 @@ impl UserInterface for HeadlessScreen {
         Ok(())
     }
 
+    fn set_tag_mask(&mut self, _mask: crate::model::TagMask) {}
+
     fn set_status_line(&mut self, _line: usize, _info: String) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/ui/help_handler.rs
+++ b/src/ui/help_handler.rs
@@ -239,7 +239,8 @@ fn load_files() -> HashMap<&'static str, &'static str> {
         "prompt" => "prompt.md",
         "prompt_mask" => "prompt_mask.md",
         "history" => "history.md",
-        "script_example" => "scripte_example.md"
+        "script_example" => "scripte_example.md",
+        "tags" => "tags.md"
     }
 }
 

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -1,7 +1,9 @@
-use crate::model::{Line, Regex};
+use crate::model::{Line, Regex, TagMask};
 
 pub struct History {
-    pub inner: Vec<Line>,
+    inner: Vec<Line>,
+    visible: Vec<Line>,
+    tag_mask: TagMask,
     pub capacity: usize,
     pub drain_length: usize,
 }
@@ -12,14 +14,31 @@ impl History {
         let capacity: usize = 32 * drain_length;
         Self {
             inner: Vec::with_capacity(capacity),
+            visible: Vec::with_capacity(capacity),
+            tag_mask: TagMask::default(),
             capacity,
             drain_length,
         }
     }
 
+    fn rebuild_visible(&mut self) {
+        self.visible = self
+            .inner
+            .iter()
+            .filter(|l| !l.is_masked(&self.tag_mask))
+            .cloned()
+            .collect();
+    }
+
+    pub fn set_tag_mask(&mut self, mask: TagMask) {
+        self.tag_mask = mask;
+        self.rebuild_visible();
+    }
+
     pub fn drain(&mut self) {
         if self.inner.len() >= self.capacity {
             self.inner.drain(0..self.drain_length);
+            self.rebuild_visible();
         }
     }
 
@@ -30,15 +49,26 @@ impl History {
     pub fn append(&mut self, line: &str) {
         if !line.trim().is_empty() {
             for segment in line.lines() {
-                self.inner.push(Line::from(segment));
+                let l = Line::from(segment);
+                if !l.is_masked(&self.tag_mask) {
+                    self.visible.push(l.clone());
+                }
+                self.inner.push(l);
             }
         } else {
-            self.inner.push(Line::from(""));
+            let l = Line::from("");
+            if !l.is_masked(&self.tag_mask) {
+                self.visible.push(l.clone());
+            }
+            self.inner.push(l);
         }
         self.drain();
     }
 
     pub fn append_line(&mut self, line: Line) {
+        if !line.is_masked(&self.tag_mask) {
+            self.visible.push(line.clone());
+        }
         self.inner.push(line);
         self.drain();
     }
@@ -46,7 +76,13 @@ impl History {
     pub fn remove_last_if_prefix(&mut self, line: &str) -> Option<Line> {
         if let Some(prefix) = self.inner.last() {
             if line.starts_with(prefix.line()) {
-                self.inner.pop()
+                let popped = self.inner.pop();
+                if let Some(ref l) = popped {
+                    if !l.is_masked(&self.tag_mask) {
+                        self.visible.pop();
+                    }
+                }
+                popped
             } else {
                 None
             }
@@ -55,27 +91,36 @@ impl History {
         }
     }
 
+    pub fn get(&self, index: usize) -> &Line {
+        &self.visible[index]
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Line> {
+        self.visible.iter()
+    }
+
     pub fn len(&self) -> usize {
-        self.inner.len()
+        self.visible.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.inner.is_empty()
+        self.visible.is_empty()
     }
 
     pub fn clear(&mut self) {
         self.inner.clear();
+        self.visible.clear();
     }
 
     pub fn find_forward(&self, pattern: &Regex, pos: usize) -> Option<usize> {
-        self.inner[pos..]
+        self.visible[pos..]
             .iter()
             .position(|l| pattern.is_match(l.clean_line()))
             .map(|index| pos + index)
     }
 
     pub fn find_backward(&self, pattern: &Regex, pos: usize) -> Option<usize> {
-        self.inner[..pos]
+        self.visible[..pos]
             .iter()
             .rev()
             .position(|l| pattern.is_match(l.clean_line()))
@@ -167,5 +212,102 @@ mod test {
         assert_eq!(history.len(), 1);
         assert_eq!(history.inner[0].clean_line(), "hello world");
         assert_eq!(history.inner[0].tag.color, "\x1b[31m");
+    }
+
+    #[test]
+    fn test_tag_mask_filters_visible() {
+        let mut history = History::new();
+        let mut masked = Line::from("combat line");
+        masked.tag.key = "combat".to_string();
+        let unmasked = Line::from("normal line");
+
+        history.append_line(masked);
+        history.append_line(unmasked);
+        assert_eq!(history.len(), 2); // No mask yet
+
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).clean_line(), "normal line");
+    }
+
+    #[test]
+    fn test_tag_mask_inner_preserved() {
+        let mut history = History::new();
+        let mut masked = Line::from("combat line");
+        masked.tag.key = "combat".to_string();
+        history.append_line(masked);
+
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+
+        assert_eq!(history.len(), 0); // not visible
+        assert_eq!(history.inner.len(), 1); // still in inner
+    }
+
+    #[test]
+    fn test_tag_mask_reset_restores_visible() {
+        let mut history = History::new();
+        let mut masked = Line::from("combat line");
+        masked.tag.key = "combat".to_string();
+        history.append_line(masked);
+        history.append_line(Line::from("normal line"));
+
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+        assert_eq!(history.len(), 1);
+
+        history.set_tag_mask(TagMask::default());
+        assert_eq!(history.len(), 2);
+    }
+
+    #[test]
+    fn test_append_line_with_active_mask() {
+        let mut history = History::new();
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+
+        let mut masked = Line::from("combat line");
+        masked.tag.key = "combat".to_string();
+        history.append_line(masked);
+        history.append_line(Line::from("normal line"));
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).clean_line(), "normal line");
+        assert_eq!(history.inner.len(), 2);
+    }
+
+    #[test]
+    fn test_remove_last_if_prefix_masked() {
+        let mut history = History::new();
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+
+        history.append_line(Line::from("normal line"));
+        let mut masked = Line::from("combat prompt");
+        masked.tag.key = "combat".to_string();
+        history.append_line(masked);
+
+        assert_eq!(history.len(), 1); // only normal in visible
+        history.remove_last_if_prefix("combat prompt extended");
+        // masked line removed from inner, visible unchanged
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.inner.len(), 1);
     }
 }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -1,7 +1,7 @@
-use crate::model::Regex;
+use crate::model::{Line, Regex};
 
 pub struct History {
-    pub inner: Vec<String>,
+    pub inner: Vec<Line>,
     pub capacity: usize,
     pub drain_length: usize,
 }
@@ -23,20 +23,29 @@ impl History {
         }
     }
 
+    pub fn append_str(&mut self, line: &str) {
+        self.append(line);
+    }
+
     pub fn append(&mut self, line: &str) {
         if !line.trim().is_empty() {
-            for line in line.lines() {
-                self.inner.push(String::from(line));
+            for segment in line.lines() {
+                self.inner.push(Line::from(segment));
             }
         } else {
-            self.inner.push("".to_string());
+            self.inner.push(Line::from(""));
         }
         self.drain();
     }
 
-    pub fn remove_last_if_prefix(&mut self, line: &str) -> Option<String> {
+    pub fn append_line(&mut self, line: Line) {
+        self.inner.push(line);
+        self.drain();
+    }
+
+    pub fn remove_last_if_prefix(&mut self, line: &str) -> Option<Line> {
         if let Some(prefix) = self.inner.last() {
-            if line.starts_with(prefix) {
+            if line.starts_with(prefix.line()) {
                 self.inner.pop()
             } else {
                 None
@@ -61,7 +70,7 @@ impl History {
     pub fn find_forward(&self, pattern: &Regex, pos: usize) -> Option<usize> {
         self.inner[pos..]
             .iter()
-            .position(|l| pattern.is_match(l))
+            .position(|l| pattern.is_match(l.clean_line()))
             .map(|index| pos + index)
     }
 
@@ -69,7 +78,7 @@ impl History {
         self.inner[..pos]
             .iter()
             .rev()
-            .position(|l| pattern.is_match(l))
+            .position(|l| pattern.is_match(l.clean_line()))
             .map(|index| pos - index - 1)
     }
 }
@@ -147,5 +156,16 @@ mod test {
             goal += 1000;
             index += 1;
         }
+    }
+
+    #[test]
+    fn test_append_line() {
+        let mut history = History::new();
+        let mut line = Line::from("hello world");
+        line.tag.color = "\x1b[31m".to_string();
+        history.append_line(line);
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.inner[0].clean_line(), "hello world");
+        assert_eq!(history.inner[0].tag.color, "\x1b[31m");
     }
 }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -291,6 +291,25 @@ mod test {
     }
 
     #[test]
+    fn test_tag_mask_reverse_shows_only_matching() {
+        let mut history = History::new();
+        let mut combat = Line::from("combat line");
+        combat.tag.key = "combat".to_string();
+        history.append_line(combat);
+        history.append_line(Line::from("normal line"));
+
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            reverse: true,
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).clean_line(), "combat line");
+    }
+
+    #[test]
     fn test_remove_last_if_prefix_masked() {
         let mut history = History::new();
         let mask = TagMask {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -18,7 +18,6 @@ mod command;
 mod headless_screen;
 mod help_handler;
 mod history;
-mod printable_chars;
 mod reader_screen;
 mod scroll_data;
 mod split_screen;

--- a/src/ui/reader_screen.rs
+++ b/src/ui/reader_screen.rs
@@ -49,7 +49,7 @@ impl ReaderScreen {
 
     #[inline]
     fn print(&mut self, line: &str, new_line: bool) {
-        self.history.append(line);
+        self.history.append_str(line);
         if !self.scroll_data.active {
             write!(
                 self.screen,
@@ -66,7 +66,7 @@ impl ReaderScreen {
     #[inline]
     fn print_line(&mut self, line: &Line) {
         if let Some(print_line) = &line.print_line() {
-            self.history.append(print_line);
+            self.history.append_str(print_line);
             if !self.scroll_data.active {
                 writeln!(
                     self.screen,
@@ -144,13 +144,12 @@ impl ReaderScreen {
     fn draw_scroll(&mut self) -> Result<()> {
         for i in 0..self.height - 1 {
             let index = self.scroll_data.pos + i as usize;
-            let line = self.history.inner[index].clone();
             write!(
                 self.screen,
                 "{}{}{}{}",
                 termion::cursor::Goto(1, i + 1),
                 termion::clear::CurrentLine,
-                line,
+                self.history.inner[index].line(),
                 cursor::Goto(1, self.prompt_line),
             )?;
         }
@@ -268,7 +267,7 @@ impl UserInterface for ReaderScreen {
             self.reset_scroll().ok();
         }
         if let Some(print_line) = send.print_line() {
-            self.history.append(print_line);
+            self.history.append_str(print_line);
         }
     }
 
@@ -290,7 +289,7 @@ impl UserInterface for ReaderScreen {
                     "{}{}{}{}",
                     cursor::Goto(1, 1 + i),
                     clear::AfterCursor,
-                    self.history.inner[index],
+                    self.history.inner[index].line(),
                     cursor::Goto(1, self.prompt_line),
                 )?;
             }
@@ -301,7 +300,7 @@ impl UserInterface for ReaderScreen {
                     "{}\n{}{}{}",
                     Goto(1, self.output_line),
                     clear::AfterCursor,
-                    line,
+                    line.line(),
                     cursor::Goto(1, self.prompt_line),
                 )?;
             }
@@ -434,6 +433,10 @@ impl UserInterface for ReaderScreen {
     }
 
     fn set_status_area_height(&mut self, _height: u16) -> Result<()> {
+        Ok(())
+    }
+
+    fn set_show_tags(&mut self, _show: bool) -> Result<()> {
         Ok(())
     }
 

--- a/src/ui/reader_screen.rs
+++ b/src/ui/reader_screen.rs
@@ -205,7 +205,7 @@ impl UserInterface for ReaderScreen {
                 let mut new_line = !line.flags.separate_receives;
                 let mut count = 0;
                 let cur_line = self.history.len();
-                for l in wrap_line(print_line, self.width as usize) {
+                for l in wrap_line(print_line, self.width as usize, 0) {
                     self.print(l, new_line);
                     new_line = true;
                     count += 1;

--- a/src/ui/reader_screen.rs
+++ b/src/ui/reader_screen.rs
@@ -149,7 +149,7 @@ impl ReaderScreen {
                 "{}{}{}{}",
                 termion::cursor::Goto(1, i + 1),
                 termion::clear::CurrentLine,
-                self.history.inner[index].line(),
+                self.history.get(index).line(),
                 cursor::Goto(1, self.prompt_line),
             )?;
         }
@@ -279,7 +279,7 @@ impl UserInterface for ReaderScreen {
     fn reset_scroll(&mut self) -> Result<()> {
         self.scroll_data.reset(&self.history)?;
         let output_range = self.output_line;
-        let output_start_index = self.history.inner.len() as i32 - output_range as i32;
+        let output_start_index = self.history.len() as i32 - output_range as i32;
         if output_start_index >= 0 {
             let output_start_index = output_start_index as usize;
             for i in 0..output_range {
@@ -289,12 +289,12 @@ impl UserInterface for ReaderScreen {
                     "{}{}{}{}",
                     cursor::Goto(1, 1 + i),
                     clear::AfterCursor,
-                    self.history.inner[index].line(),
+                    self.history.get(index).line(),
                     cursor::Goto(1, self.prompt_line),
                 )?;
             }
         } else {
-            for line in &self.history.inner {
+            for line in self.history.iter() {
                 write!(
                     self.screen,
                     "{}\n{}{}{}",
@@ -331,7 +331,7 @@ impl UserInterface for ReaderScreen {
         self.scroll_data.clamp(&self.history);
         if self.scroll_data.active {
             let output_range = self.output_line as i32;
-            let max_start_index = self.history.inner.len() as i32 - output_range;
+            let max_start_index = self.history.len() as i32 - output_range;
             let new_start_index = self.scroll_data.pos + 5;
             if new_start_index >= max_start_index as usize {
                 self.reset_scroll()?;
@@ -350,7 +350,7 @@ impl UserInterface for ReaderScreen {
     fn scroll_to(&mut self, row: usize) -> Result<()> {
         self.scroll_data.clamp(&self.history);
         if self.history.len() > self.output_line as usize {
-            let max_start_index = self.history.inner.len() as i32 - self.output_line as i32;
+            let max_start_index = self.history.len() as i32 - self.output_line as i32;
             if max_start_index > 0 && row < max_start_index as usize {
                 self.scroll_data.active = true;
                 self.scroll_data.pos = row;
@@ -363,7 +363,7 @@ impl UserInterface for ReaderScreen {
     }
 
     fn scroll_top(&mut self) -> Result<()> {
-        if self.history.inner.len() as u16 >= self.output_line {
+        if self.history.len() as u16 >= self.output_line {
             self.scroll_data.active = true;
             self.scroll_data.pos = 0;
             self.draw_scroll()?;
@@ -374,10 +374,10 @@ impl UserInterface for ReaderScreen {
     fn scroll_up(&mut self) -> Result<()> {
         self.scroll_data.clamp(&self.history);
         let output_range = self.output_line as usize;
-        if self.history.inner.len() > output_range {
+        if self.history.len() > output_range {
             if !self.scroll_data.active {
                 self.scroll_data.active = true;
-                self.scroll_data.pos = self.history.inner.len() - output_range;
+                self.scroll_data.pos = self.history.len() - output_range;
             }
             self.scroll_data.pos -= self.scroll_data.pos.min(5);
             self.draw_scroll()?;
@@ -439,6 +439,8 @@ impl UserInterface for ReaderScreen {
     fn set_show_tags(&mut self, _show: bool) -> Result<()> {
         Ok(())
     }
+
+    fn set_tag_mask(&mut self, _mask: crate::model::TagMask) {}
 
     fn set_status_line(&mut self, _line: usize, _info: String) -> Result<()> {
         Ok(())

--- a/src/ui/reader_screen.rs
+++ b/src/ui/reader_screen.rs
@@ -8,9 +8,8 @@ use termion::{
 
 use crate::{
     model::{Line, Regex},
-    ui::{
-        printable_chars::PrintableCharsIterator, DisableOriginMode, ResetScrollRegion, ScrollRegion,
-    },
+    tools::printable_chars::PrintableCharsIterator,
+    ui::{DisableOriginMode, ResetScrollRegion, ScrollRegion},
 };
 
 use super::{

--- a/src/ui/scroll_data.rs
+++ b/src/ui/scroll_data.rs
@@ -91,7 +91,7 @@ mod test {
 
         let mut history = History::new();
         for _ in 0..1024 {
-            history.append("test")
+            history.append_str("test")
         }
         assert!(scroll.pos > history.len());
         scroll.clamp(&history);
@@ -146,7 +146,7 @@ mod test {
 
         let mut history = History::new();
         for _ in 0..1024 {
-            history.append("test")
+            history.append_str("test")
         }
         // When not active, clamp should not modify pos
         scroll.clamp(&history);
@@ -163,7 +163,7 @@ mod test {
 
         let mut history = History::new();
         for _ in 0..100 {
-            history.append("line");
+            history.append_str("line");
         }
 
         assert!(scroll.reset(&history).is_ok());

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -5,7 +5,7 @@ use super::wrap_line;
 use crate::io::SaveData;
 use crate::model::{Settings, HIDE_TOPBAR};
 use crate::{
-    model::Line, model::Regex, model::ToLine, ui::ansi::*,
+    model::Line, model::Regex, model::TagMask, model::ToLine, ui::ansi::*,
     ui::printable_chars::PrintableCharsIterator,
 };
 use anyhow::Result;
@@ -180,6 +180,7 @@ pub struct SplitScreen {
     prompt_input: String,
     prompt_input_pos: usize,
     show_tags: bool,
+    tag_mask: TagMask,
 }
 
 impl UserInterface for SplitScreen {
@@ -369,7 +370,7 @@ impl UserInterface for SplitScreen {
         self.redraw_prompt();
 
         let output_range = self.output_range();
-        let output_start_index = self.history.inner.len() as i32 - output_range as i32;
+        let output_start_index = self.history.len() as i32 - output_range as i32;
         if output_start_index >= 0 {
             let output_start_index = output_start_index as usize;
             for i in 0..output_range {
@@ -385,7 +386,7 @@ impl UserInterface for SplitScreen {
                 )?;
             }
         } else {
-            for i in 0..self.history.inner.len() {
+            for i in 0..self.history.len() {
                 let rendered = self.render_history_line(i);
                 write!(
                     self.screen,
@@ -426,7 +427,7 @@ impl UserInterface for SplitScreen {
         self.scroll_data.clamp(&self.history);
         if self.scroll_data.active {
             let output_range = self.scroll_range() as i32;
-            let max_start_index: i32 = self.history.inner.len() as i32 - output_range;
+            let max_start_index: i32 = self.history.len() as i32 - output_range;
             let new_start_index = self.scroll_data.pos + 5;
             if new_start_index >= max_start_index as usize {
                 self.reset_scroll()?;
@@ -445,7 +446,7 @@ impl UserInterface for SplitScreen {
     fn scroll_to(&mut self, row: usize) -> Result<()> {
         self.scroll_data.clamp(&self.history);
         if self.history.len() > self.scroll_range() as usize {
-            let max_start_index = self.history.inner.len() as i32 - self.scroll_range() as i32;
+            let max_start_index = self.history.len() as i32 - self.scroll_range() as i32;
             if max_start_index > 0 && row < max_start_index as usize {
                 self.init_scroll()?;
                 self.scroll_data.pos = row;
@@ -458,7 +459,7 @@ impl UserInterface for SplitScreen {
     }
 
     fn scroll_top(&mut self) -> Result<()> {
-        if self.history.inner.len() as u16 >= self.output_line {
+        if self.history.len() as u16 >= self.output_line {
             self.init_scroll()?;
             self.scroll_data.pos = 0;
             self.draw_scroll()?;
@@ -469,10 +470,10 @@ impl UserInterface for SplitScreen {
     fn scroll_up(&mut self) -> Result<()> {
         self.scroll_data.clamp(&self.history);
         let output_range: usize = self.scroll_range() as usize;
-        if self.history.inner.len() > output_range {
+        if self.history.len() > output_range {
             if !self.scroll_data.active {
                 self.init_scroll()?;
-                self.scroll_data.pos = self.history.inner.len() - output_range;
+                self.scroll_data.pos = self.history.len() - output_range;
             }
             self.scroll_data.pos -= self.scroll_data.pos.min(5);
             self.draw_scroll()?;
@@ -549,6 +550,12 @@ impl UserInterface for SplitScreen {
         self.setup()
     }
 
+    fn set_tag_mask(&mut self, mask: TagMask) {
+        self.tag_mask = mask.clone();
+        self.history.set_tag_mask(mask);
+        self.setup().ok();
+    }
+
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()> {
         self.status_area.set_status_line(line, info);
         self.status_area.redraw_line(&mut self.screen, line)?;
@@ -604,11 +611,12 @@ impl SplitScreen {
             prompt_input: String::new(),
             prompt_input_pos: 0,
             show_tags: false,
+            tag_mask: TagMask::default(),
         })
     }
 
     fn render_history_line(&self, index: usize) -> String {
-        let line = &self.history.inner[index];
+        let line = self.history.get(index);
         if self.show_tags {
             line.tagged_line().unwrap_or_default()
         } else {
@@ -617,6 +625,11 @@ impl SplitScreen {
     }
 
     fn print_line(&mut self, line: Line) {
+        let masked = line.is_masked(&self.tag_mask);
+        self.history.append_line(line.clone());
+        if masked {
+            return;
+        }
         let rendered = if self.show_tags {
             line.tagged_line().unwrap_or_default()
         } else {
@@ -632,7 +645,6 @@ impl SplitScreen {
             )
             .unwrap();
         }
-        self.history.append_line(line);
     }
 
     fn clear_prompt(&mut self) {
@@ -745,7 +757,7 @@ impl SplitScreen {
         let output_range = self.scroll_range();
         for i in 0..output_range {
             let index = self.scroll_data.pos + i as usize;
-            if index >= self.history.inner.len() {
+            if index >= self.history.len() {
                 // History has been trimmed during scrolling
                 // TODO: It should be possible to lock history during render perhaps?
                 // The lock would prevent the drain function until scrolls is done.
@@ -801,7 +813,7 @@ mod screen_test {
 
         let mut history = History::new();
         history.append(line);
-        let content: Vec<&str> = history.inner.iter().map(|l| l.line()).collect();
+        let content: Vec<&str> = history.iter().map(|l| l.line()).collect();
         assert_eq!(
             content,
             vec![
@@ -846,5 +858,81 @@ mod screen_test {
         assert_eq!(history.len(), 19);
         history.append("test");
         assert_eq!(history.len(), 10);
+    }
+
+    // Tests for print_line tag mask behaviour. SplitScreen::new requires a real
+    // terminal so we exercise the behaviour through History directly, which is
+    // what print_line delegates to.
+
+    #[test]
+    fn test_print_line_masked_stored_in_inner_not_visible() {
+        // Simulates print_line: always calls history.append_line, skips
+        // rendering when masked. Verify masked line lands in inner but not
+        // visible.
+        let mut history = History::new();
+        history.set_tag_mask(TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        });
+
+        let mut masked = Line::from("combat hit");
+        masked.tag.key = "combat".to_string();
+        // print_line always appends regardless of mask
+        history.append_line(masked);
+        history.append_line(Line::from("normal line"));
+
+        assert_eq!(history.len(), 1); // only unmasked in visible
+        assert_eq!(history.get(0).clean_line(), "normal line");
+    }
+
+    #[test]
+    fn test_print_line_unmasked_line_visible() {
+        let mut history = History::new();
+        history.set_tag_mask(TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        });
+
+        history.append_line(Line::from("system message"));
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).clean_line(), "system message");
+    }
+
+    #[test]
+    fn test_set_tag_mask_retroactive() {
+        // Simulates set_tag_mask on SplitScreen: history is rebuilt from inner
+        // so previously appended lines are filtered retroactively.
+        let mut history = History::new();
+
+        let mut combat = Line::from("combat hit");
+        combat.tag.key = "combat".to_string();
+        history.append_line(combat);
+        history.append_line(Line::from("normal line"));
+        assert_eq!(history.len(), 2);
+
+        history.set_tag_mask(TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).clean_line(), "normal line");
+    }
+
+    #[test]
+    fn test_clear_tag_mask_restores_all_lines() {
+        let mut history = History::new();
+        let mut combat = Line::from("combat hit");
+        combat.tag.key = "combat".to_string();
+        history.append_line(combat);
+        history.append_line(Line::from("normal line"));
+
+        history.set_tag_mask(TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(history.len(), 1);
+
+        history.set_tag_mask(TagMask::default());
+        assert_eq!(history.len(), 2);
     }
 }

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -4,7 +4,10 @@ use super::user_interface::TerminalSizeError;
 use super::wrap_line;
 use crate::io::SaveData;
 use crate::model::{Settings, HIDE_TOPBAR};
-use crate::{model::Line, model::Regex, ui::ansi::*, ui::printable_chars::PrintableCharsIterator};
+use crate::{
+    model::Line, model::Regex, model::ToLine, ui::ansi::*,
+    ui::printable_chars::PrintableCharsIterator,
+};
 use anyhow::Result;
 use std::collections::HashSet;
 use std::io::Write;
@@ -176,6 +179,7 @@ pub struct SplitScreen {
     tags: HashSet<String>,
     prompt_input: String,
     prompt_input_pos: usize,
+    show_tags: bool,
 }
 
 impl UserInterface for SplitScreen {
@@ -219,12 +223,12 @@ impl UserInterface for SplitScreen {
 
     fn print_error(&mut self, output: &str) {
         let line = &format!("{}[!!] {}{}", Fg(color::Red), output, Fg(color::Reset));
-        self.print_line(line);
+        self.print_line(line.to_internal_line());
     }
 
     fn print_info(&mut self, output: &str) {
         let line = &format!("[**] {output}");
-        self.print_line(line);
+        self.print_line(line.to_internal_line());
     }
 
     fn print_output(&mut self, line: &Line) {
@@ -233,19 +237,26 @@ impl UserInterface for SplitScreen {
         if line.flags.screen_clear {
             self.clear_output_area().ok();
         }
-        if let Some(print_line) = line.tagged_line() {
-            if !line.is_utf8() || print_line.trim().is_empty() {
-                self.print_line(&print_line);
-            } else {
-                let mut count = 0;
-                let cur_line = self.history.len();
-                for l in wrap_line(&print_line, self.width as usize) {
-                    self.print_line(l);
-                    count += 1;
-                }
-                if self.scroll_data.scroll_lock && count > self.height {
-                    self.scroll_to(cur_line).ok();
-                }
+        let raw = match line.print_line() {
+            Some(r) => r,
+            None => return,
+        };
+        if !line.is_utf8() || raw.trim().is_empty() {
+            self.print_line(line.clone());
+        } else {
+            let segments: Vec<String> = wrap_line(raw, self.width as usize)
+                .into_iter()
+                .map(str::to_string)
+                .collect();
+            let count = segments.len();
+            let cur_line = self.history.len();
+            for segment in segments {
+                let mut entry = line.clone();
+                entry.set_content(&segment);
+                self.print_line(entry);
+            }
+            if self.scroll_data.scroll_lock && count > self.height as usize {
+                self.scroll_to(cur_line).ok();
             }
         }
     }
@@ -329,7 +340,7 @@ impl UserInterface for SplitScreen {
                 Fg(color::Reset),
             );
             for line in wrap_line(line, self.width as usize) {
-                self.print_line(line);
+                self.print_line(line.to_internal_line());
             }
         }
     }
@@ -364,21 +375,23 @@ impl UserInterface for SplitScreen {
             for i in 0..output_range {
                 let index = output_start_index + i as usize;
                 let line_no = self.output_start_line + i;
+                let rendered = self.render_history_line(index);
                 write!(
                     self.screen,
                     "{}{}{}",
                     termion::cursor::Goto(1, line_no),
                     termion::clear::CurrentLine,
-                    self.history.inner[index],
+                    rendered,
                 )?;
             }
         } else {
-            for line in &self.history.inner {
+            for i in 0..self.history.inner.len() {
+                let rendered = self.render_history_line(i);
                 write!(
                     self.screen,
                     "{}\n{}",
                     termion::cursor::Goto(1, self.output_line),
-                    line,
+                    rendered,
                 )?;
             }
         }
@@ -531,6 +544,11 @@ impl UserInterface for SplitScreen {
         Ok(())
     }
 
+    fn set_show_tags(&mut self, show: bool) -> Result<()> {
+        self.show_tags = show;
+        self.setup()
+    }
+
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()> {
         self.status_area.set_status_line(line, info);
         self.status_area.redraw_line(&mut self.screen, line)?;
@@ -585,21 +603,36 @@ impl SplitScreen {
             tags: HashSet::new(),
             prompt_input: String::new(),
             prompt_input_pos: 0,
+            show_tags: false,
         })
     }
 
-    fn print_line(&mut self, line: &str) {
-        self.history.append(line);
+    fn render_history_line(&self, index: usize) -> String {
+        let line = &self.history.inner[index];
+        if self.show_tags {
+            line.tagged_line().unwrap_or_default()
+        } else {
+            line.print_line().unwrap_or_default().to_string()
+        }
+    }
+
+    fn print_line(&mut self, line: Line) {
+        let rendered = if self.show_tags {
+            line.tagged_line().unwrap_or_default()
+        } else {
+            line.print_line().unwrap_or_default().to_string()
+        };
         if self.scroll_data.not_scrolled_or_split() {
             write!(
                 self.screen,
                 "{}\r\n{}{}",
                 termion::cursor::Goto(1, self.output_line),
-                &line,
+                &rendered,
                 self.goto_prompt(),
             )
             .unwrap();
         }
+        self.history.append_line(line);
     }
 
     fn clear_prompt(&mut self) {
@@ -614,7 +647,11 @@ impl SplitScreen {
     }
 
     fn redraw_prompt(&mut self) {
-        let prompt_line = self.mud_prompt.tagged_line().unwrap_or_default();
+        let prompt_line = if self.show_tags {
+            self.mud_prompt.tagged_line().unwrap_or_default()
+        } else {
+            self.mud_prompt.print_line().unwrap_or("").to_string()
+        };
         let prompt_line = prompt_line.as_str();
         if self.scroll_data.not_scrolled_or_split() {
             write!(
@@ -715,11 +752,11 @@ impl SplitScreen {
                 break;
             }
             let line_no = self.output_start_line + i;
-            let mut line = self.history.inner[index].clone();
+            let mut rendered = self.render_history_line(index);
             if let Some(pattern) = &self.scroll_data.hilite {
-                line = pattern
+                rendered = pattern
                     .replace_all(
-                        &line,
+                        &rendered,
                         format!(
                             "{}{}$0{}{}",
                             Fg(color::LightWhite),
@@ -735,7 +772,7 @@ impl SplitScreen {
                 "{}{}{}",
                 termion::cursor::Goto(1, line_no),
                 termion::clear::CurrentLine,
-                line,
+                rendered,
             )?;
         }
         Ok(())
@@ -764,8 +801,9 @@ mod screen_test {
 
         let mut history = History::new();
         history.append(line);
+        let content: Vec<&str> = history.inner.iter().map(|l| l.line()).collect();
         assert_eq!(
-            history.inner,
+            content,
             vec![
                 "a nice line",
                 "",

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -5,8 +5,8 @@ use super::wrap_line;
 use crate::io::SaveData;
 use crate::model::{Settings, HIDE_TOPBAR};
 use crate::{
-    model::Line, model::Regex, model::TagMask, model::ToLine, ui::ansi::*,
-    ui::printable_chars::PrintableCharsIterator,
+    model::Line, model::Regex, model::TagMask, model::ToLine,
+    tools::printable_chars::PrintableCharsIterator, ui::ansi::*,
 };
 use anyhow::Result;
 use std::collections::HashSet;

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -233,13 +233,13 @@ impl UserInterface for SplitScreen {
         if line.flags.screen_clear {
             self.clear_output_area().ok();
         }
-        if let Some(print_line) = line.print_line() {
+        if let Some(print_line) = line.tagged_line() {
             if !line.is_utf8() || print_line.trim().is_empty() {
-                self.print_line(print_line);
+                self.print_line(&print_line);
             } else {
                 let mut count = 0;
                 let cur_line = self.history.len();
-                for l in wrap_line(print_line, self.width as usize) {
+                for l in wrap_line(&print_line, self.width as usize) {
                     self.print_line(l);
                     count += 1;
                 }
@@ -614,7 +614,8 @@ impl SplitScreen {
     }
 
     fn redraw_prompt(&mut self) {
-        let prompt_line = self.mud_prompt.print_line().unwrap_or("");
+        let prompt_line = self.mud_prompt.tagged_line().unwrap_or_default();
+        let prompt_line = prompt_line.as_str();
         if self.scroll_data.not_scrolled_or_split() {
             write!(
                 self.screen,

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -245,7 +245,8 @@ impl UserInterface for SplitScreen {
         if !line.is_utf8() || raw.trim().is_empty() {
             self.print_line(line.clone());
         } else {
-            let segments: Vec<String> = wrap_line(raw, self.width as usize)
+            let padding = if self.show_tags { 2 } else { 0 };
+            let segments: Vec<String> = wrap_line(raw, self.width as usize, padding)
                 .into_iter()
                 .map(str::to_string)
                 .collect();
@@ -340,7 +341,11 @@ impl UserInterface for SplitScreen {
                 line,
                 Fg(color::Reset),
             );
-            for line in wrap_line(line, self.width as usize) {
+            for line in wrap_line(
+                line,
+                self.width as usize,
+                if self.show_tags { 2 } else { 0 },
+            ) {
                 self.print_line(line.to_internal_line());
             }
         }

--- a/src/ui/ui_wrapper.rs
+++ b/src/ui/ui_wrapper.rs
@@ -171,6 +171,10 @@ impl UserInterface for UiWrapper {
         self.screen.set_status_area_height(height)
     }
 
+    fn set_show_tags(&mut self, show: bool) -> Result<()> {
+        self.screen.set_show_tags(show)
+    }
+
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()> {
         self.screen.set_status_line(line, info)
     }

--- a/src/ui/ui_wrapper.rs
+++ b/src/ui/ui_wrapper.rs
@@ -175,6 +175,10 @@ impl UserInterface for UiWrapper {
         self.screen.set_show_tags(show)
     }
 
+    fn set_tag_mask(&mut self, mask: crate::model::TagMask) {
+        self.screen.set_tag_mask(mask);
+    }
+
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()> {
         self.screen.set_status_line(line, info)
     }

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -56,6 +56,7 @@ pub trait UserInterface {
     fn remove_tag(&mut self, proto: &str) -> Result<()>;
     fn clear_tags(&mut self) -> Result<()>;
     fn set_status_area_height(&mut self, height: u16) -> Result<()>;
+    fn set_show_tags(&mut self, show: bool) -> Result<()>;
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()>;
     fn flush(&mut self);
     fn width(&self) -> u16;

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -3,7 +3,7 @@ use std::{error, fmt, io::Write};
 #[cfg(test)]
 use mockall::automock;
 
-use crate::model::{Line, Regex};
+use crate::model::{Line, Regex, TagMask};
 
 use anyhow::Result;
 
@@ -57,6 +57,7 @@ pub trait UserInterface {
     fn clear_tags(&mut self) -> Result<()>;
     fn set_status_area_height(&mut self, height: u16) -> Result<()>;
     fn set_show_tags(&mut self, show: bool) -> Result<()>;
+    fn set_tag_mask(&mut self, mask: TagMask);
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()>;
     fn flush(&mut self);
     fn width(&self) -> u16;

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -4,6 +4,7 @@ use std::{error, fmt, io::Write};
 use mockall::automock;
 
 use crate::model::{Line, Regex, TagMask};
+use crate::tools::printable_chars::PrintableCharsIterator;
 
 use anyhow::Result;
 
@@ -65,33 +66,8 @@ pub trait UserInterface {
     fn destroy(self: Box<Self>) -> Result<(Box<dyn Write>, History)>;
 }
 
-/// Tracks the parser state for ANSI/VT escape sequences during line wrapping.
-/// This allows wrap_line to correctly skip over all escape sequences when
-/// calculating printable line width, not just SGR (\x1b[...m) sequences.
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum EscapeState {
-    /// Normal text — characters contribute to print width.
-    Ground,
-    /// Saw ESC (\x1b), waiting to see what kind of sequence follows.
-    Escape,
-    /// Inside a CSI sequence (\x1b[...) — terminated by any byte in 0x40..=0x7E.
-    Csi,
-    /// Inside an OSC sequence (\x1b]...) — terminated by BEL (\x07) or ST (\x1b\\).
-    Osc,
-    /// Inside an OSC sequence, just saw ESC — might be the ST terminator (\x1b\\).
-    OscEscSeen,
-    /// Inside a DCS (\x1bP), SOS (\x1bX), PM (\x1b^), or APC (\x1b_) string —
-    /// terminated by ST (\x1b\\).
-    StringSeq,
-    /// Inside a string sequence, just saw ESC — might be the ST terminator.
-    StringEscSeen,
-    /// Saw ESC followed by an intermediate byte (e.g. '(', ')', '*', '+', '%')
-    /// for charset designation sequences like ESC ( B, ESC ) 0, etc.
-    /// Consumes the next (final) byte and returns to Ground.
-    EscapeIntermediate,
-}
-
-pub fn wrap_line(line: &str, width: usize) -> Vec<&str> {
+pub fn wrap_line(line: &str, width: usize, padding: usize) -> Vec<&str> {
+    let width = width.saturating_sub(padding);
     let mut lines: Vec<&str> = vec![];
 
     for line in line.lines() {
@@ -105,94 +81,7 @@ pub fn wrap_line(line: &str, width: usize) -> Vec<&str> {
         let mut last_space: usize = 0;
         let mut print_length = 0;
         let mut print_length_since_space = 0;
-        let mut state = EscapeState::Ground;
-        for (length, c) in line.char_indices() {
-            match state {
-                EscapeState::Ground => {
-                    if c == '\x1b' {
-                        state = EscapeState::Escape;
-                        continue;
-                    }
-                }
-                EscapeState::Escape => {
-                    match c {
-                        '[' => {
-                            state = EscapeState::Csi;
-                            continue;
-                        }
-                        ']' => {
-                            state = EscapeState::Osc;
-                            continue;
-                        }
-                        // DCS, SOS, PM, APC — string sequences terminated by ST
-                        'P' | 'X' | '^' | '_' => {
-                            state = EscapeState::StringSeq;
-                            continue;
-                        }
-                        // Charset designation sequences: ESC ( F, ESC ) F, ESC * F,
-                        // ESC + F, ESC % F — intermediate byte + one final byte.
-                        '(' | ')' | '*' | '+' | '%' => {
-                            state = EscapeState::EscapeIntermediate;
-                            continue;
-                        }
-                        // Two-character escape sequences (e.g. ESC c, ESC 7, ESC 8, etc.)
-                        // and any other ESC + single byte — consume and return to ground.
-                        _ => {
-                            state = EscapeState::Ground;
-                            continue;
-                        }
-                    }
-                }
-                EscapeState::EscapeIntermediate => {
-                    // Consume the final byte of the charset designation sequence
-                    // (e.g. 'B' in ESC ( B, '0' in ESC ) 0) and return to ground.
-                    state = EscapeState::Ground;
-                    continue;
-                }
-                EscapeState::Csi => {
-                    // CSI parameters and intermediates: 0x20..=0x3F
-                    // Final byte: 0x40..=0x7E (any ASCII letter or @[\]^_`{|}~)
-                    if c as u32 >= 0x40 && c as u32 <= 0x7E {
-                        state = EscapeState::Ground;
-                    }
-                    continue;
-                }
-                EscapeState::Osc => {
-                    if c == '\x07' {
-                        // BEL terminates OSC
-                        state = EscapeState::Ground;
-                    } else if c == '\x1b' {
-                        // Might be start of ST (\x1b\\)
-                        state = EscapeState::OscEscSeen;
-                    }
-                    continue;
-                }
-                EscapeState::OscEscSeen => {
-                    // After ESC inside OSC: if '\' then ST terminates, otherwise
-                    // stay in OSC (the ESC was part of the OSC content).
-                    if c == '\\' {
-                        state = EscapeState::Ground;
-                    } else {
-                        state = EscapeState::Osc;
-                    }
-                    continue;
-                }
-                EscapeState::StringSeq => {
-                    if c == '\x1b' {
-                        state = EscapeState::StringEscSeen;
-                    }
-                    continue;
-                }
-                EscapeState::StringEscSeen => {
-                    if c == '\\' {
-                        state = EscapeState::Ground;
-                    } else {
-                        state = EscapeState::StringSeq;
-                    }
-                    continue;
-                }
-            }
-
+        for (length, c) in line.printable_char_indices() {
             // Keep track of printable line length
             print_length += 1;
 
@@ -235,13 +124,27 @@ mod tests {
     fn test_wrap_line() {
         let line: &'static str =
             "\x1b[34mSomething \x1b[0mthat's pretty \x1b[32mlong and annoying\x1b[0m";
-        let lines = wrap_line(line, 11);
+        let lines = wrap_line(line, 11, 0);
         let mut iter = lines.iter();
         assert_eq!(iter.next(), Some(&"\u{1b}[34mSomething"));
         assert_eq!(iter.next(), Some(&"\u{1b}[0mthat's"));
         assert_eq!(iter.next(), Some(&"pretty"));
         assert_eq!(iter.next(), Some(&"\u{1b}[32mlong and"));
         assert_eq!(iter.next(), Some(&"annoying\u{1b}[0m"));
+    }
+
+    #[test]
+    fn test_wrap_line_with_padding() {
+        // "hello world!!" is 13 printable chars.
+        // At width=14 with no padding it fits on one line.
+        // With padding=2 the effective width is 12, so it must wrap at the space.
+        let line = "hello world!!";
+        let lines = wrap_line(line, 14, 0);
+        assert_eq!(lines.len(), 1);
+        let lines = wrap_line(line, 14, 2);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], "hello");
+        assert_eq!(lines[1], "world!!");
     }
 
     #[test]
@@ -253,7 +156,7 @@ mod tests {
                 line = format!("{}{}", line, num.repeat(15));
             }
         }
-        let lines = wrap_line(&line, 15);
+        let lines = wrap_line(&line, 15, 0);
         assert_eq!(lines.len(), 1000 * 10);
         for (i, line) in lines.iter().enumerate() {
             let num = format!("{}", i % 10);
@@ -265,7 +168,7 @@ mod tests {
     fn test_wrap_line_with_osc8_hyperlink() {
         // Simulates mdcat OSC 8 hyperlink output: ESC]8;;url ESC\ visible_text ESC]8;; ESC\
         let line = "Visit \x1b]8;;https://example.com\x1b\\\x1b[34mhttps://example.com\x1b[0m\x1b]8;;\x1b\\ for info";
-        let lines = wrap_line(line, 80);
+        let lines = wrap_line(line, 80, 0);
         // The entire line fits in 80 columns (printable: "Visit https://example.com for info" = 34 chars)
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0], line);
@@ -277,7 +180,7 @@ mod tests {
         // This test ensures the visible link text is counted toward print width.
         let link = "\x1b]8;;http://x.co\x1b\\click here\x1b]8;;\x1b\\";
         // "click here" = 10 printable chars; at width 5 it must wrap.
-        let lines = wrap_line(link, 5);
+        let lines = wrap_line(link, 5, 0);
         // 2 pieces: OSC-open + "click", " here" — trailing OSC-close escape bytes
         // are emitted as a separate segment (zero printable width).
         assert_eq!(lines.len(), 3);
@@ -290,7 +193,7 @@ mod tests {
         // CSI sequences other than SGR (e.g. cursor movement ESC[H, erase ESC[K)
         // should also be skipped.
         let line = "\x1b[Hsome text\x1b[K";
-        let lines = wrap_line(line, 80);
+        let lines = wrap_line(line, 80, 0);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0], line);
     }
@@ -301,7 +204,7 @@ mod tests {
         // ESC * A, ESC + C, ESC % @ etc. — should all be skipped without consuming
         // visible text.
         let line = "\x1b(Bhello \x1b)0world\x1b*A!\x1b+C\x1b%@";
-        let lines = wrap_line(line, 80);
+        let lines = wrap_line(line, 80, 0);
         // Printable: "hello world!" = 12 chars, fits in 80 columns
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0], line);
@@ -312,7 +215,7 @@ mod tests {
         // Ensure charset designation sequences don't affect wrap width calculation.
         let line = "\x1b(Babcde\x1b)0fghij";
         // "abcdefghij" = 10 printable chars; at width 5 it must wrap.
-        let lines = wrap_line(line, 5);
+        let lines = wrap_line(line, 5, 0);
         assert_eq!(lines.len(), 2);
     }
 }

--- a/tests/lua_tests.rs
+++ b/tests/lua_tests.rs
@@ -33,6 +33,11 @@ fn regex_smoke_tests() {
 }
 
 #[test]
+fn test_line_tags() {
+    test_script("tests/tag_tests.lua");
+}
+
+#[test]
 fn test_mud() -> Result<()> {
     let mut server = common::Server::bind(0);
     let mut rt = RuntimeConfig::default();

--- a/tests/tag_tests.lua
+++ b/tests/tag_tests.lua
@@ -1,0 +1,60 @@
+require("tests.common")
+
+local triggers = trigger.add_group()
+
+script.on_reset(function()
+    blight.quit()
+end)
+
+-- Track which tagged lines were seen
+local tagged_combat = false
+local tagged_loot = false
+local untagged_seen = false
+
+-- Trigger: tag "combat" lines with a red color and "combat" key
+triggers:add("^combat line$", {}, function(_, line)
+    line:tag_color("\x1b[31m")
+    line:tag_key("combat")
+    line:tag_symbol("!")
+end)
+
+-- Trigger: tag "loot" lines with a green color and "loot" key
+triggers:add("^loot line$", {}, function(_, line)
+    line:tag_color("\x1b[32m")
+    line:tag_key("loot")
+end)
+
+mud.add_output_listener(function(line)
+    local key = line:tag_key()
+    local color = line:tag_color()
+    local symbol = line:tag_symbol()
+
+    if line:line() == "combat line" then
+        assert_eq(key, "combat")
+        assert_eq(color, "\x1b[31m")
+        assert_eq(symbol, "!")
+        tagged_combat = true
+    elseif line:line() == "loot line" then
+        assert_eq(key, "loot")
+        assert_eq(color, "\x1b[32m")
+        tagged_loot = true
+    elseif line:line() == "plain line" then
+        assert_eq(key, "")
+        assert_eq(color, "")
+        untagged_seen = true
+    end
+
+    return line
+end)
+
+mud.output("combat line")
+mud.output("loot line")
+mud.output("plain line")
+
+timer.add(1, 1, function()
+    assert(tagged_combat, "combat line was not tagged")
+    assert(tagged_loot, "loot line was not tagged")
+    assert(untagged_seen, "plain line was not seen without tags")
+
+    script.reset()
+end)


### PR DESCRIPTION
This is just the initial step for the new tag feature. Remaining pieces
are:

- Opt out of tag rendering (setting)
    * Important since tags indent output 2 spaces.
- Re-drawing the view with only history lines matching a given 'key'.
    * Needs a lua function to enables/disable this filter
- Setting for the default tag symbol. Lua function?
