### PR TITLE
Make rodio optional

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,9 +43,12 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy, rustfmt
-      - name: Test
+      - name: Test feature combinations
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: cargo test --locked
+        run: |
+          cargo test --locked --no-default-features --features spellcheck
+          cargo test --locked --no-default-features
+          cargo test --locked
       - name: Test (all features)
         if: ${{ matrix.os != 'ubuntu-latest' }}
         run: cargo test --locked --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ doctest = false
 crate-type = ["rlib"]
 
 [features]
-default = ["spellcheck"]
+default = ["spellcheck", "audio"]
 text-to-speech = ["tts"]
 spellcheck = ["hunspell-rs", "hunspell-sys"]
+audio = ["rodio"]
 
 [dependencies]
 libmudtelnet = "2.0.1"
@@ -45,7 +46,7 @@ human-panic = "2.0.8"
 tts = { version = "0.26.3", optional = true }
 serde_json = "1.0.149"
 git2 = "0.20.4"
-rodio = "0.22.2"
+rodio = { version = "0.22.2", optional = true }
 notify-debouncer-mini = "0.6.0"
 hunspell-rs = { version = "0.4.0", optional = true }
 hunspell-sys = { version = "0.3.0", features = ['bundled'], optional = true }

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ build Blightmud without the spellcheck feature, use `--no-default-features`. E.g
 - Run `cargo build --no-default-features` or `cargo build --no-default-features --features text-to-speech`
 - Run `cargo run --no-default-features` or `cargo run --no-default-features --features text-to-speech` to run
 
+### Compile without audio
+
+If you're running Blightmud on a server or system without ALSA/audio libraries, you can disable
+audio support to avoid requiring these dependencies:
+
+- Install rust
+- Run `cargo build --no-default-features --features spellcheck`
+- Run `cargo run --no-default-features --features spellcheck` to run
+
+You can combine with other features as needed:
+- With text-to-speech: `cargo build --no-default-features --features spellcheck,text-to-speech`
+- Minimal build (no audio, no spellcheck): `cargo build --no-default-features`
+
 ### Nix
 
 If you're using [Nix](https://nixos.org/) or NixOS you can try Blightmud

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,3 +1,12 @@
-pub use self::{handler::handle_audio_event, player::Player, player::SourceOptions};
+#[cfg(feature = "audio")]
 mod handler;
+#[cfg(feature = "audio")]
 mod player;
+
+#[cfg(feature = "audio")]
+pub use self::{handler::handle_audio_event, player::Player, player::SourceOptions};
+
+#[cfg(not(feature = "audio"))]
+mod stub;
+#[cfg(not(feature = "audio"))]
+pub use self::stub::{handle_audio_event, Player, SourceOptions};

--- a/src/audio/stub.rs
+++ b/src/audio/stub.rs
@@ -1,0 +1,30 @@
+// Stub types for when audio feature is disabled
+// These are used when compiling without the 'audio' feature flag
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SourceOptions {
+    pub repeat: bool,
+    pub amplify: f32,
+}
+
+impl Default for SourceOptions {
+    fn default() -> Self {
+        Self {
+            repeat: false,
+            amplify: 1.0,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Player;
+
+impl Player {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+pub fn handle_audio_event(_event: crate::event::Event, _player: &mut Player) -> anyhow::Result<()> {
+    Ok(())
+}


### PR DESCRIPTION
- Adds an audio feature (default-on) that gates the rodio dependency, so Blightmud can be built on hosts without ALSA libs
- When the feature is off, src/audio/stub.rs provides no-op Player, SourceOptions, and handle_audio_event so lib.rs and the Lua bindings need no cfg branches
- README documents the no-audio build, and the Linux CI job now covers spellcheck-only, no-features, and default builds

Resolves #1295.