### PR TITLE
Timestamp debug logfiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,18 @@ cargo build --features=tts && \
     ./target/debug/blightmud -V
 ```
 
+Running Blightmud in verbose mode (`--verbose` or `-V`) writes a timestamped logfile at `./.run/data/logs/log.<YYYYMMDD>.<HH:MM:SS>.txt` (or, in a release build, at `$XDG_DATA_HOME/blightmud/logs/`).
+
+This command tails the output of the mosst recently created such logfile:
+
 ```bash
 # Terminal B - Blightmud debug log
-tail -F ./.run/data/logs/log.txt
+tail -F "$(ls -t ./.run/data/logs/log.*.txt | head -n1)"
 ```
+
+If you have several debug sessions running at once, target the specific file you want.
+
+Then, in another terminal, run `gdb`:
 
 ```bash
 # Terminal C - GDB

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ cargo build --features=tts && \
 
 Running Blightmud in verbose mode (`--verbose` or `-V`) writes a timestamped logfile at `./.run/data/logs/log.<YYYYMMDD>.<HH:MM:SS>.txt` (or, in a release build, at `$XDG_DATA_HOME/blightmud/logs/`).
 
-This command tails the output of the mosst recently created such logfile:
+This command tails the output of the most recently created such logfile:
 
 ```bash
 # Terminal B - Blightmud debug log

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ fn register_terminal_resize_listener(session: Session) -> thread::JoinHandle<()>
         .unwrap()
 }
 
-fn start_logging(log_level: log::LevelFilter) -> std::io::Result<()> {
+fn start_logging(log_level: log::LevelFilter, verbose: bool) -> std::io::Result<()> {
     let log_level = if cfg!(debug_assertions) {
         log::LevelFilter::Debug
     } else {
@@ -117,10 +117,14 @@ fn start_logging(log_level: log::LevelFilter) -> std::io::Result<()> {
     let logpath = DATA_DIR.clone().join("logs");
     std::fs::create_dir_all(&logpath)?;
 
-    let logfile = logpath.join(format!(
-        "log.{}.txt",
-        Local::now().format("%Y%m%d.%H:%M:%S")
-    ));
+    let logfile = if verbose {
+        logpath.join(format!(
+            "log.{}.txt",
+            Local::now().format("%Y%m%d.%H:%M:%S")
+        ))
+    } else {
+        logpath.join("log.txt")
+    };
 
     simple_logging::log_to_file(logfile.to_str().unwrap(), log_level)?;
 
@@ -182,7 +186,7 @@ pub fn start(rt: RuntimeConfig) -> Result<()> {
         log::LevelFilter::Info
     };
 
-    if let Err(e) = start_logging(log_level) {
+    if let Err(e) = start_logging(log_level, rt.verbose) {
         panic!("[!!] Logging failed to start: {e:?}");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use audio::Player;
+use chrono::Local;
 use lazy_static::lazy_static;
 use libmudtelnet::events::TelnetEvents;
 use log::{error, info};
@@ -116,7 +117,10 @@ fn start_logging(log_level: log::LevelFilter) -> std::io::Result<()> {
     let logpath = DATA_DIR.clone().join("logs");
     std::fs::create_dir_all(&logpath)?;
 
-    let logfile = logpath.join("log.txt");
+    let logfile = logpath.join(format!(
+        "log.{}.txt",
+        Local::now().format("%Y%m%d.%H:%M:%S")
+    ));
 
     simple_logging::log_to_file(logfile.to_str().unwrap(), log_level)?;
 


### PR DESCRIPTION
Currently, when running in verbose mode (`--verbose` or `-V`), the logfile gets written to the same place: the hardcoded path `./.run/data/logs/log.txt`. This means that if you run Blightmud a second time in verbose mode, the second log will clobber the first; furthermore, running more than one instance of Blightmud verbosely will cause them both to write to the same logfile.

This PR timestamps the logfiles when they are being created, as: `./.run/data/logs/log.<YYYYMMDD>.<HH:MM:SS>.txt`

This has the effects that you can run more than one Blightmud at a time in verbose mode, and also that you can safely run a verbose a second time, secure in the knowledge that your first logfile won't go anywhere.

This PR also updates `CONTRIBUTING.md` with a command to tail the output of just the most recently-created verbose logfile.