### PR TITLE
Allow customizing the content of the top bar

### DIFF
--- a/resources/help/settings.md
+++ b/resources/help/settings.md
@@ -49,7 +49,7 @@ Available settings are:
 - `scroll_lock`         Set scroll position at start of text when showing long help files.
 - `tts_enabled`         Enable tts (only if compiled with TTS).
 - `reader_mode`         Switches to a screen reader friendly TUI. (Does not support `status area`).
-- `hide_topbar`         Toggles the topbar.
+- `hide_topbar`         Toggles the topbar. To customise the content, see `/help top_line`.
 - `echo_input`          Toggles whether user input is echoed on-screen with a `> ` prefix.
 - `last_command`        Toggles whether last command is persisted for easy repeat submission.
 

--- a/resources/help/top_line.md
+++ b/resources/help/top_line.md
@@ -1,0 +1,10 @@
+# Top line method
+
+This method allows you to control the content of the top line. By default, the top line shows the host of the server you are connected
+to as well as all of the protocols that the server supports. To hide the top bar completely, set toggle the `hide_topbar` setting. See `/help settings`.
+
+##
+
+***blight.top_line(line)***
+Sets the content of the top line. The content will be integrated into the bar.
+- `line`    The line you want to print. Passing `nil` will reset the bar to the default content.

--- a/resources/lua/types/blightmud.d.lua
+++ b/resources/lua/types/blightmud.d.lua
@@ -275,6 +275,10 @@ function BlightLib.status_height(height) end
 ---@param index integer  0-based line index.
 ---@param line string
 function BlightLib.status_line(index, line) end
+---
+---Sets the content of the top bar line.
+---@param line string  The content to display. nil will reset to default content.
+function BlightLib.top_line(line) end
 
 ---Gets or sets whether tag rendering is enabled. When enabled, each output
 ---line is prefixed with the line's tag symbol and color (or two spaces if no

--- a/src/event.rs
+++ b/src/event.rs
@@ -81,6 +81,7 @@ pub enum Event {
     StopLogging,
     StopMusic,
     StopSFX,
+    TopLine(Option<String>),
     TTSEnabled(bool),
     TTSEvent(TTSEvent),
     TimedEvent(u32),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,6 +499,7 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
             Event::ShowTags(show) => screen.set_show_tags(show)?,
             Event::SetTagMask(mask) => screen.set_tag_mask(mask),
             Event::StatusLine(index, info) => screen.set_status_line(index, info)?,
+            Event::TopLine(info) => screen.set_top_line(info)?,
             Event::LoadScript(path) => {
                 info!("Loading script: {}", path);
                 let mut lua = session.lua_script.lock().unwrap();

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -137,9 +137,7 @@ impl UserData for Blight {
         methods.add_function("top_line", |ctx, line: Option<String>| {
             let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
             let this = this_aux.borrow::<Blight>()?;
-            this.main_writer
-                .send(Event::TopLine(line))
-                .unwrap();
+            this.main_writer.send(Event::TopLine(line)).unwrap();
             Ok(())
         });
         methods.add_function("version", |_, _: ()| -> LuaResult<(&str, &str)> {

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -134,6 +134,14 @@ impl UserData for Blight {
                 .unwrap();
             Ok(())
         });
+        methods.add_function("top_line", |ctx, line: Option<String>| {
+            let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
+            let this = this_aux.borrow::<Blight>()?;
+            this.main_writer
+                .send(Event::TopLine(line))
+                .unwrap();
+            Ok(())
+        });
         methods.add_function("version", |_, _: ()| -> LuaResult<(&str, &str)> {
             Ok((PROJECT_NAME, VERSION))
         });

--- a/src/ui/headless_screen.rs
+++ b/src/ui/headless_screen.rs
@@ -106,6 +106,10 @@ impl UserInterface for HeadlessScreen {
         Ok(())
     }
 
+    fn set_top_line(&mut self, _info: Option<String>) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     fn flush(&mut self) {
         std::io::stdout().flush().ok();
     }

--- a/src/ui/reader_screen.rs
+++ b/src/ui/reader_screen.rs
@@ -445,6 +445,10 @@ impl UserInterface for ReaderScreen {
         Ok(())
     }
 
+    fn set_top_line(&mut self, _info: Option<String>) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     fn flush(&mut self) {
         self.screen.flush().unwrap();
     }

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -181,6 +181,7 @@ pub struct SplitScreen {
     prompt_input_pos: usize,
     show_tags: bool,
     tag_mask: TagMask,
+    top_line: Option<String>,
 }
 
 impl UserInterface for SplitScreen {
@@ -567,6 +568,11 @@ impl UserInterface for SplitScreen {
         Ok(())
     }
 
+    fn set_top_line(&mut self, line: Option<String>) -> Result<()> {
+        self.top_line = line;
+        self.redraw_top_bar()
+    }
+
     fn flush(&mut self) {
         self.screen.flush().unwrap();
     }
@@ -616,6 +622,7 @@ impl SplitScreen {
             prompt_input_pos: 0,
             show_tags: false,
             tag_mask: TagMask::default(),
+            top_line: None,
         })
     }
 
@@ -682,32 +689,65 @@ impl SplitScreen {
         }
     }
 
+    fn default_top_bar(&self) -> String {
+        let host = if let Some(connection) = &self.connection {
+            connection
+        } else {
+            &String::default() // Empty String
+        };
+        let mut tags = self
+            .tags
+            .iter()
+            .map(|s| format!("[{s}]"))
+            .collect::<Vec<String>>();
+        tags.sort();
+        let tags = tags.join("");
+        let mut output = format!("{host}{tags}");
+        if !output.is_empty() {
+            output.push(' ');
+        }
+        return output;
+    }
+
+    // Almost identical to StatusArea.draw_bar, but with a double line bar character
+    fn draw_bar(width: usize, line: usize, screen: &mut impl Write, custom_info: &str) -> Result<()> {
+        write!(
+            screen,
+            "{}{}{}",
+            termion::cursor::Goto(1, line as u16),
+            termion::clear::CurrentLine,
+            Fg(color::Green),
+        )?;
+
+        let custom_info = if !custom_info.trim().is_empty() {
+            format!(
+                "═ {}{}{} ",
+                custom_info.trim(),
+                Fg(color::Reset),
+                Fg(color::Green)
+            )
+        } else {
+            "".to_string()
+        };
+
+        let info_line = Line::from(&custom_info);
+        let stripped_chars = info_line.line().len() - info_line.clean_line().len();
+
+        write!(
+            screen,
+            "{:═<1$}",
+            &custom_info,
+            width + stripped_chars
+        )?; // Print separator
+        write!(screen, "{}", Fg(color::Reset))?;
+        Ok(())
+    }
+
     fn redraw_top_bar(&mut self) -> Result<()> {
         if self.output_start_line > 1 {
-            write!(
-                self.screen,
-                "{}{}{}",
-                termion::cursor::Goto(1, 1),
-                termion::clear::CurrentLine,
-                Fg(color::Green),
-            )?;
-            let host = if let Some(connection) = &self.connection {
-                format!("═ {connection} ")
-            } else {
-                "".to_string()
-            };
-            let mut tags = self
-                .tags
-                .iter()
-                .map(|s| format!("[{s}]"))
-                .collect::<Vec<String>>();
-            tags.sort();
-            let tags = tags.join("");
-            let mut output = format!("{host}{tags}");
-            if !output.is_empty() {
-                output.push(' ');
-            }
-            write!(self.screen, "{:═<1$}", output, self.width as usize)?; // Print separator
+            let mut default_output = String::default();
+            let output = self.top_line.as_ref().unwrap_or_else(|| { default_output = self.default_top_bar(); &default_output });
+            Self::draw_bar(self.width as usize, 1, &mut self.screen, output)?;
             write!(self.screen, "{}{}", Fg(color::Reset), self.goto_prompt(),)?;
         }
         Ok(())

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -21,6 +21,54 @@ const PROMPT_HEIGHT: u16 = 1;
 const STATUS_HEIGHT_MIN: u16 = 0;
 const STATUS_HEIGHT_MAX: u16 = 5;
 
+fn repeat_char(c: char, n: usize) -> String {
+    let mut s = String::with_capacity(n * c.len_utf8());
+    for _ in 0..n {
+        s.push(c);
+    }
+    s
+}
+
+fn draw_bar(
+    barchar: char,
+    width: usize,
+    line: usize,
+    screen: &mut impl Write,
+    custom_info: &str,
+) -> Result<()> {
+    write!(
+        screen,
+        "{}{}{}",
+        termion::cursor::Goto(1, line as u16),
+        termion::clear::CurrentLine,
+        Fg(color::Green),
+    )?;
+
+    let custom_info = if !custom_info.trim().is_empty() {
+        format!(
+            "{} {}{}{}{} ",
+            barchar,
+            custom_info.trim(),
+            Bg(color::Reset),
+            Fg(color::Reset),
+            Fg(color::Green)
+        )
+    } else {
+        "".to_string()
+    };
+
+    let remainder = width - custom_info.as_str().display_width();
+
+    write!(screen, "{}", &custom_info)?;
+
+    if remainder > 0 {
+        screen.write_all(repeat_char(barchar, remainder).as_bytes())?;
+    }
+
+    write!(screen, "{}", Fg(color::Reset))?;
+    Ok(())
+}
+
 struct StatusArea {
     start_line: u16,
     width: u16,
@@ -97,7 +145,7 @@ impl StatusArea {
         }
 
         if line_no == 0 || line_no == self.status_lines.len() - 1 {
-            self.draw_bar(index, screen, &info)?;
+            draw_bar('━', self.width as usize, index, screen, &info)?;
         } else {
             self.draw_line(index, screen, &info)?;
         }
@@ -109,39 +157,6 @@ impl StatusArea {
         for line in 0..self.status_lines.len() {
             self.redraw_line(screen, line)?;
         }
-        Ok(())
-    }
-
-    fn draw_bar(&self, line: usize, screen: &mut impl Write, custom_info: &str) -> Result<()> {
-        write!(
-            screen,
-            "{}{}{}",
-            termion::cursor::Goto(1, line as u16),
-            termion::clear::CurrentLine,
-            Fg(color::Green),
-        )?;
-
-        let custom_info = if !custom_info.trim().is_empty() {
-            format!(
-                "━ {}{}{} ",
-                custom_info.trim(),
-                Fg(color::Reset),
-                Fg(color::Green)
-            )
-        } else {
-            "".to_string()
-        };
-
-        let info_line = Line::from(&custom_info);
-        let stripped_chars = info_line.line().len() - info_line.clean_line().len();
-
-        write!(
-            screen,
-            "{:━<1$}",
-            &custom_info,
-            self.width as usize + stripped_chars
-        )?; // Print separator
-        write!(screen, "{}", Fg(color::Reset))?;
         Ok(())
     }
 
@@ -706,42 +721,7 @@ impl SplitScreen {
         if !output.is_empty() {
             output.push(' ');
         }
-        return output;
-    }
-
-    // Almost identical to StatusArea.draw_bar, but with a double line bar character
-    fn draw_bar(
-        width: usize,
-        line: usize,
-        screen: &mut impl Write,
-        custom_info: &str,
-    ) -> Result<()> {
-        write!(
-            screen,
-            "{}{}{}",
-            termion::cursor::Goto(1, line as u16),
-            termion::clear::CurrentLine,
-            Fg(color::Green),
-        )?;
-
-        let custom_info = if !custom_info.trim().is_empty() {
-            format!(
-                "═ {}{}{}{} ",
-                custom_info.trim(),
-                Bg(color::Reset),
-                Fg(color::Reset),
-                Fg(color::Green)
-            )
-        } else {
-            "".to_string()
-        };
-
-        let info_line = Line::from(&custom_info);
-        let stripped_chars = info_line.line().len() - info_line.clean_line().len();
-
-        write!(screen, "{:═<1$}", &custom_info, width + stripped_chars)?; // Print separator
-        write!(screen, "{}", Fg(color::Reset))?;
-        Ok(())
+        output
     }
 
     fn redraw_top_bar(&mut self) -> Result<()> {
@@ -751,7 +731,8 @@ impl SplitScreen {
                 default_output = self.default_top_bar();
                 &default_output
             });
-            Self::draw_bar(self.width as usize, 1, &mut self.screen, output)?;
+
+            draw_bar('═', self.width as usize, 1, &mut self.screen, output)?;
             write!(self.screen, "{}{}", Fg(color::Reset), self.goto_prompt(),)?;
         }
         Ok(())
@@ -982,5 +963,35 @@ mod screen_test {
 
         history.set_tag_mask(TagMask::default());
         assert_eq!(history.len(), 2);
+    }
+
+    #[test]
+    fn test_draw_bar_pads_to_length_ignoring_escape_sequences() {
+        let mut buf = Vec::<u8>::new();
+
+        draw_bar('━', 10, 1, &mut buf, "test").unwrap();
+
+        let clean_output = String::from_utf8(buf)
+            .unwrap()
+            .as_str()
+            .printable_chars()
+            .collect::<String>();
+
+        assert_eq!(clean_output, "━ test ━━━");
+    }
+
+    #[test]
+    fn test_draw_bar_is_unbroken_for_empty_string() {
+        let mut buf = Vec::<u8>::new();
+
+        draw_bar('━', 10, 1, &mut buf, "").unwrap();
+
+        let clean_output = String::from_utf8(buf)
+            .unwrap()
+            .as_str()
+            .printable_chars()
+            .collect::<String>();
+
+        assert_eq!(clean_output, "━━━━━━━━━━");
     }
 }

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -710,7 +710,12 @@ impl SplitScreen {
     }
 
     // Almost identical to StatusArea.draw_bar, but with a double line bar character
-    fn draw_bar(width: usize, line: usize, screen: &mut impl Write, custom_info: &str) -> Result<()> {
+    fn draw_bar(
+        width: usize,
+        line: usize,
+        screen: &mut impl Write,
+        custom_info: &str,
+    ) -> Result<()> {
         write!(
             screen,
             "{}{}{}",
@@ -733,12 +738,7 @@ impl SplitScreen {
         let info_line = Line::from(&custom_info);
         let stripped_chars = info_line.line().len() - info_line.clean_line().len();
 
-        write!(
-            screen,
-            "{:═<1$}",
-            &custom_info,
-            width + stripped_chars
-        )?; // Print separator
+        write!(screen, "{:═<1$}", &custom_info, width + stripped_chars)?; // Print separator
         write!(screen, "{}", Fg(color::Reset))?;
         Ok(())
     }
@@ -746,7 +746,10 @@ impl SplitScreen {
     fn redraw_top_bar(&mut self) -> Result<()> {
         if self.output_start_line > 1 {
             let mut default_output = String::default();
-            let output = self.top_line.as_ref().unwrap_or_else(|| { default_output = self.default_top_bar(); &default_output });
+            let output = self.top_line.as_ref().unwrap_or_else(|| {
+                default_output = self.default_top_bar();
+                &default_output
+            });
             Self::draw_bar(self.width as usize, 1, &mut self.screen, output)?;
             write!(self.screen, "{}{}", Fg(color::Reset), self.goto_prompt(),)?;
         }

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -702,7 +702,7 @@ impl SplitScreen {
             .collect::<Vec<String>>();
         tags.sort();
         let tags = tags.join("");
-        let mut output = format!("{host}{tags}");
+        let mut output = format!("{host} {tags}");
         if !output.is_empty() {
             output.push(' ');
         }

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -726,8 +726,9 @@ impl SplitScreen {
 
         let custom_info = if !custom_info.trim().is_empty() {
             format!(
-                "═ {}{}{} ",
+                "═ {}{}{}{} ",
                 custom_info.trim(),
+                Bg(color::Reset),
                 Fg(color::Reset),
                 Fg(color::Green)
             )

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -44,11 +44,13 @@ fn draw_bar(
         Fg(color::Green),
     )?;
 
-    let custom_info = if !custom_info.trim().is_empty() {
+    let trimmed = custom_info.trim();
+    let custom_info = if !trimmed.is_empty() {
+        let (max_bytes, _) = trimmed.byte_index_at_display_width(width - 4);
         format!(
             "{} {}{}{}{} ",
             barchar,
-            custom_info.trim(),
+            trimmed.get(0..max_bytes).unwrap_or(trimmed), // If byte index is bad, skip truncation
             Bg(color::Reset),
             Fg(color::Reset),
             Fg(color::Green)
@@ -993,5 +995,20 @@ mod screen_test {
             .collect::<String>();
 
         assert_eq!(clean_output, "━━━━━━━━━━");
+    }
+
+    #[test]
+    fn test_draw_bar_truncates_long_text() {
+        let mut buf = Vec::<u8>::new();
+
+        draw_bar('━', 10, 1, &mut buf, "this text is too long").unwrap();
+
+        let clean_output = String::from_utf8(buf)
+            .unwrap()
+            .as_str()
+            .printable_chars()
+            .collect::<String>();
+
+        assert_eq!(clean_output, "━ this t ━");
     }
 }

--- a/src/ui/ui_wrapper.rs
+++ b/src/ui/ui_wrapper.rs
@@ -183,6 +183,10 @@ impl UserInterface for UiWrapper {
         self.screen.set_status_line(line, info)
     }
 
+    fn set_top_line(&mut self, info: Option<String>) -> Result<()> {
+        self.screen.set_top_line(info)
+    }
+
     fn flush(&mut self) {
         self.screen.flush();
     }

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -60,6 +60,7 @@ pub trait UserInterface {
     fn set_show_tags(&mut self, show: bool) -> Result<()>;
     fn set_tag_mask(&mut self, mask: TagMask);
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()>;
+    fn set_top_line(&mut self, info: Option<String>) -> Result<()>;
     fn flush(&mut self);
     fn width(&self) -> u16;
     fn height(&self) -> u16;


### PR DESCRIPTION
- Added new lua function `blight.top_line` to set the text content of the top line.
  - Text will be integrated into the bar in the same manner as bar lines in the status area
  - Passing an empty string will result in an unbroken bar
  - Passing `nil` will reset to the default content (server hostname and tags)
  - Text that is too long will be truncated to fit within the bar

Current top bar behaviour should be unchanged if the user doesn't call this function.