### PR TITLE
Fix codec encoding when sending text to server

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -162,7 +162,14 @@ impl EventHandler {
                     if !line.flags.matched {
                         if let Ok(mut parser) = self.session.telnet_parser.lock() {
                             if let TelnetEvents::DataSend(buffer) = parser.send_text(line.line()) {
-                                self.session.main_writer.send(Event::ServerSend(buffer))?;
+                                let data = if let Some(codec) = self.session._codec {
+                                    let text = std::str::from_utf8(&buffer).unwrap_or_default();
+                                    let (encoded, _, _) = codec.encode(text);
+                                    Bytes::copy_from_slice(&encoded)
+                                } else {
+                                    buffer
+                                };
+                                self.session.main_writer.send(Event::ServerSend(data))?;
                             }
                         }
                     }


### PR DESCRIPTION
Fixes a bug where the `--codec` option only handled the receive direction (server→client) but missed the send direction (client→server).

**Problem:**
When connecting to a GBK-encoded MUD server, players could read server output correctly but any Chinese characters they typed would be sent as UTF-8 and appear garbled on the server side.

**Solution:**
In `src/event.rs`, when handling `Event::ServerInput`, if a codec is configured, encode the output buffer from UTF-8 to the target encoding before sending.

**Files modified:**
- `src/event.rs`