### PR TITLE
Optimize history drain

### DIFF
--- a/resources/help/blight.md
+++ b/resources/help/blight.md
@@ -60,6 +60,25 @@ Returns blightmuds config directory path on the current system
 
 ##
 
+***blight.history_capacity([capacity]) -> int***
+Get or set the scrollback buffer capacity. When called without arguments,
+returns the current capacity. When called with a capacity argument, sets the
+new capacity and trims excess lines if necessary.
+
+- `capacity`  The maximum number of lines to keep in the scrollback buffer (int)
+- Returns the current history capacity
+
+```lua
+-- Get current capacity
+local cap = blight.history_capacity()
+print("Current capacity: " .. cap)
+
+-- Set new capacity
+blight.history_capacity(5000)
+```
+
+##
+
 ***blight.data_dir() -> Path***
 Returns blightmuds data directory path on the current system
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -90,6 +90,7 @@ pub enum Event {
     SetPromptMask(PromptMask),
     ClearPromptMask,
     SetTagMask(TagMask),
+    SetHistoryCapacity(usize),
     UserInputBuffer(String, usize),
     UserInputCursor(usize),
     FSEvent(FSEvent),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,6 +506,7 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
             Event::StatusAreaHeight(height) => screen.set_status_area_height(height)?,
             Event::ShowTags(show) => screen.set_show_tags(show)?,
             Event::SetTagMask(mask) => screen.set_tag_mask(mask),
+            Event::SetHistoryCapacity(capacity) => screen.set_history_capacity(capacity),
             Event::StatusLine(index, info) => screen.set_status_line(index, info)?,
             Event::LoadScript(path) => {
                 info!("Loading script: {}", path);

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -577,4 +577,31 @@ mod test_blight {
             .unwrap();
         assert_eq!(height, 1);
     }
+
+    #[test]
+    fn test_history_capacity() {
+        let (lua, reader) = get_lua_state();
+
+        // Default value
+        let cap = lua
+            .load("return blight.history_capacity()")
+            .call::<usize>(())
+            .unwrap();
+        assert_eq!(cap, 32768);
+
+        // Set new value
+        let cap = lua
+            .load("return blight.history_capacity(5000)")
+            .call::<usize>(())
+            .unwrap();
+        assert_eq!(cap, 5000);
+        assert_eq!(reader.recv(), Ok(Event::SetHistoryCapacity(5000)));
+
+        // Getter reflects update
+        let cap = lua
+            .load("return blight.history_capacity()")
+            .call::<usize>(())
+            .unwrap();
+        assert_eq!(cap, 5000);
+    }
 }

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -21,6 +21,7 @@ pub struct Blight {
     pub reader_mode: bool,
     pub _tts_enabled: bool,
     tag_mask: TagMask,
+    history_capacity: usize,
 }
 
 impl Blight {
@@ -34,6 +35,7 @@ impl Blight {
             reader_mode: false,
             _tts_enabled: false,
             tag_mask: TagMask::default(),
+            history_capacity: 32768,
         }
     }
 
@@ -239,6 +241,17 @@ impl UserData for Blight {
                 .send(Event::SetTagMask(this.tag_mask.clone()))
                 .unwrap();
             Ok(())
+        });
+        methods.add_function("history_capacity", |ctx, capacity: Option<usize>| {
+            let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
+            let mut this = this_aux.borrow_mut::<Blight>()?;
+            if let Some(capacity) = capacity {
+                this.history_capacity = capacity;
+                this.main_writer
+                    .send(Event::SetHistoryCapacity(capacity))
+                    .unwrap();
+            }
+            Ok(this.history_capacity)
         });
         methods.add_function("find_backward", |ctx, re: Regex| {
             let this_aux = ctx.globals().get::<AnyUserData>("blight")?;

--- a/src/ui/headless_screen.rs
+++ b/src/ui/headless_screen.rs
@@ -102,6 +102,8 @@ impl UserInterface for HeadlessScreen {
 
     fn set_tag_mask(&mut self, _mask: crate::model::TagMask) {}
 
+    fn set_history_capacity(&mut self, _capacity: usize) {}
+
     fn set_status_line(&mut self, _line: usize, _info: String) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -37,14 +37,18 @@ impl History {
 
     pub fn set_capacity(&mut self, new_capacity: usize) {
         self.capacity = new_capacity;
-        while self.inner.len() > self.capacity {
-            let drained = self.inner.remove(0);
-            if !drained.is_masked(&self.tag_mask) {
-                if !self.visible.is_empty() {
-                    self.visible.remove(0);
+        if self.inner.len() > self.capacity {
+            let excess = self.inner.len() - self.capacity;
+            let drained: Vec<Line> = self.inner.drain(0..excess).collect();
+            let visible_drain_count = drained
+                .iter()
+                .filter(|l| !l.is_masked(&self.tag_mask))
+                .count();
+            if visible_drain_count > 0 {
+                if visible_drain_count <= self.visible.len() {
+                    self.visible.drain(0..visible_drain_count);
                 } else {
                     self.rebuild_visible();
-                    return;
                 }
             }
         }
@@ -52,7 +56,8 @@ impl History {
 
     pub fn drain(&mut self) {
         if self.inner.len() >= self.capacity {
-            let drained: Vec<Line> = self.inner.drain(0..self.drain_length).collect();
+            let drain_len = self.drain_length.min(self.inner.len());
+            let drained: Vec<Line> = self.inner.drain(0..drain_len).collect();
             let visible_drain_count = drained
                 .iter()
                 .filter(|l| !l.is_masked(&self.tag_mask))

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -522,4 +522,65 @@ mod test {
             assert!(!history.visible[i].is_masked(&history.tag_mask));
         }
     }
+
+    #[test]
+    fn test_drain_with_small_capacity_clamps_drain_length() {
+        let mut history = History::new();
+        history.set_capacity(5);
+        for i in 0..10 {
+            history.append(&format!("line {}", i));
+        }
+        // capacity is 5, drain_length is 1024 but should be clamped
+        assert!(history.inner.len() <= 5);
+        assert!(history.visible.len() <= history.inner.len());
+    }
+
+    #[test]
+    fn test_set_capacity_zero() {
+        let mut history = History::new();
+        for i in 0..100 {
+            history.append(&format!("line {}", i));
+        }
+        history.set_capacity(0);
+        assert_eq!(history.capacity, 0);
+        assert_eq!(history.inner.len(), 0);
+        assert_eq!(history.visible.len(), 0);
+    }
+
+    #[test]
+    fn test_set_capacity_one() {
+        let mut history = History::new();
+        for i in 0..100 {
+            history.append(&format!("line {}", i));
+        }
+        history.set_capacity(1);
+        assert_eq!(history.capacity, 1);
+        assert_eq!(history.inner.len(), 1);
+        assert_eq!(history.visible.len(), 1);
+    }
+
+    #[test]
+    fn test_set_capacity_visible_inner_consistency() {
+        let mut history = History::new();
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+
+        for i in 0..1000 {
+            let mut line = Line::from(&format!("line {}", i));
+            if i % 3 == 0 {
+                line.tag.key = "combat".to_string();
+            }
+            history.append_line(line);
+        }
+
+        history.set_capacity(200);
+        assert_eq!(history.inner.len(), 200);
+        // Verify visible is a proper subset of inner
+        for i in 0..history.visible.len() {
+            assert!(!history.visible[i].is_masked(&history.tag_mask));
+        }
+    }
 }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -37,8 +37,14 @@ impl History {
 
     pub fn drain(&mut self) {
         if self.inner.len() >= self.capacity {
-            self.inner.drain(0..self.drain_length);
-            self.rebuild_visible();
+            let drained: Vec<Line> = self.inner.drain(0..self.drain_length).collect();
+            let visible_drain_count = drained
+                .iter()
+                .filter(|l| !l.is_masked(&self.tag_mask))
+                .count();
+            if visible_drain_count > 0 {
+                self.visible.drain(0..visible_drain_count);
+            }
         }
     }
 
@@ -328,5 +334,61 @@ mod test {
         // masked line removed from inner, visible unchanged
         assert_eq!(history.len(), 1);
         assert_eq!(history.inner.len(), 1);
+    }
+
+    #[test]
+    fn test_drain_incremental_no_mask() {
+        let mut history = History::new();
+        for i in 0..history.capacity - 1 {
+            history.append(&format!("line {}", i));
+        }
+        assert_eq!(history.inner.len(), history.capacity - 1);
+        let visible_before = history.len();
+        history.append("overflow line");
+        assert_eq!(history.inner.len(), history.capacity - history.drain_length);
+        assert_eq!(history.len(), visible_before - history.drain_length + 1);
+    }
+
+    #[test]
+    fn test_drain_incremental_with_mask() {
+        let mut history = History::new();
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+
+        for i in 0..history.capacity - 1 {
+            let mut line = Line::from(&format!("line {}", i));
+            if i % 2 == 0 {
+                line.tag.key = "combat".to_string();
+            }
+            history.append_line(line);
+        }
+        let visible_before = history.len();
+        let inner_before = history.inner.len();
+        assert_eq!(inner_before, history.capacity - 1);
+
+        let mut overflow = Line::from("overflow");
+        overflow.tag.key = "combat".to_string();
+        history.append_line(overflow);
+
+        assert_eq!(history.inner.len(), inner_before - history.drain_length + 1);
+        let drained_visible = visible_before - history.len() + 1;
+        assert!(drained_visible <= history.drain_length);
+    }
+
+    #[test]
+    fn test_drain_visible_inner_consistency() {
+        let mut history = History::new();
+        for i in 0..history.capacity + 100 {
+            history.append(&format!("line {}", i));
+        }
+        let visible_count = history.visible.len();
+        let inner_count = history.inner.len();
+        assert_eq!(visible_count, inner_count);
+        for i in 0..visible_count {
+            assert_eq!(history.visible[i].line(), history.inner[i].line());
+        }
     }
 }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -39,7 +39,7 @@ impl History {
         self.capacity = new_capacity;
         while self.inner.len() > self.capacity {
             let drained = self.inner.remove(0);
-            if !drained.is_masked(&self.tag_mask) {
+            if !drained.is_masked(&self.tag_mask) && !self.visible.is_empty() {
                 self.visible.remove(0);
             }
         }
@@ -52,7 +52,7 @@ impl History {
                 .iter()
                 .filter(|l| !l.is_masked(&self.tag_mask))
                 .count();
-            if visible_drain_count > 0 {
+            if visible_drain_count > 0 && visible_drain_count <= self.visible.len() {
                 self.visible.drain(0..visible_drain_count);
             }
         }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -39,8 +39,13 @@ impl History {
         self.capacity = new_capacity;
         while self.inner.len() > self.capacity {
             let drained = self.inner.remove(0);
-            if !drained.is_masked(&self.tag_mask) && !self.visible.is_empty() {
-                self.visible.remove(0);
+            if !drained.is_masked(&self.tag_mask) {
+                if !self.visible.is_empty() {
+                    self.visible.remove(0);
+                } else {
+                    self.rebuild_visible();
+                    return;
+                }
             }
         }
     }
@@ -52,8 +57,12 @@ impl History {
                 .iter()
                 .filter(|l| !l.is_masked(&self.tag_mask))
                 .count();
-            if visible_drain_count > 0 && visible_drain_count <= self.visible.len() {
-                self.visible.drain(0..visible_drain_count);
+            if visible_drain_count > 0 {
+                if visible_drain_count <= self.visible.len() {
+                    self.visible.drain(0..visible_drain_count);
+                } else {
+                    self.rebuild_visible();
+                }
             }
         }
     }
@@ -458,5 +467,54 @@ mod test {
         assert_eq!(history.capacity, 500);
         assert_eq!(history.inner.len(), 100);
         assert_eq!(history.visible.len(), 100);
+    }
+
+    #[test]
+    fn test_drain_with_heavy_mask_no_panic() {
+        let mut history = History::new();
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+
+        for i in 0..history.capacity + 100 {
+            let mut line = Line::from(&format!("line {}", i));
+            if i % 10 != 0 {
+                line.tag.key = "combat".to_string();
+            }
+            history.append_line(line);
+        }
+
+        assert!(history.inner.len() <= history.capacity);
+        assert!(history.visible.len() <= history.inner.len());
+        for i in 0..history.visible.len() {
+            assert!(!history.visible[i].is_masked(&history.tag_mask));
+        }
+    }
+
+    #[test]
+    fn test_set_capacity_with_heavy_mask_no_panic() {
+        let mut history = History::new();
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+
+        for i in 0..1000 {
+            let mut line = Line::from(&format!("line {}", i));
+            if i % 10 != 0 {
+                line.tag.key = "combat".to_string();
+            }
+            history.append_line(line);
+        }
+
+        history.set_capacity(100);
+        assert_eq!(history.inner.len(), 100);
+        assert!(history.visible.len() <= history.inner.len());
+        for i in 0..history.visible.len() {
+            assert!(!history.visible[i].is_masked(&history.tag_mask));
+        }
     }
 }

--- a/src/ui/history.rs
+++ b/src/ui/history.rs
@@ -35,6 +35,16 @@ impl History {
         self.rebuild_visible();
     }
 
+    pub fn set_capacity(&mut self, new_capacity: usize) {
+        self.capacity = new_capacity;
+        while self.inner.len() > self.capacity {
+            let drained = self.inner.remove(0);
+            if !drained.is_masked(&self.tag_mask) {
+                self.visible.remove(0);
+            }
+        }
+    }
+
     pub fn drain(&mut self) {
         if self.inner.len() >= self.capacity {
             let drained: Vec<Line> = self.inner.drain(0..self.drain_length).collect();
@@ -390,5 +400,63 @@ mod test {
         for i in 0..visible_count {
             assert_eq!(history.visible[i].line(), history.inner[i].line());
         }
+    }
+
+    #[test]
+    fn test_set_capacity_reduces_lines() {
+        let mut history = History::new();
+        for i in 0..1000 {
+            history.append(&format!("line {}", i));
+        }
+        assert_eq!(history.inner.len(), 1000);
+        assert_eq!(history.visible.len(), 1000);
+
+        history.set_capacity(500);
+        assert_eq!(history.capacity, 500);
+        assert_eq!(history.inner.len(), 500);
+        assert_eq!(history.visible.len(), 500);
+        assert_eq!(history.visible[0].line(), "line 500");
+    }
+
+    #[test]
+    fn test_set_capacity_with_mask() {
+        let mut history = History::new();
+        let mask = TagMask {
+            key: Some("combat".to_string()),
+            ..Default::default()
+        };
+        history.set_tag_mask(mask);
+
+        for i in 0..1000 {
+            let mut line = Line::from(&format!("line {}", i));
+            if i % 2 == 0 {
+                line.tag.key = "combat".to_string();
+            }
+            history.append_line(line);
+        }
+        let visible_before = history.len();
+        let inner_before = history.inner.len();
+        assert_eq!(inner_before, 1000);
+        assert!(visible_before < inner_before);
+
+        history.set_capacity(500);
+        assert_eq!(history.capacity, 500);
+        assert_eq!(history.inner.len(), 500);
+        let visible_after = history.len();
+        assert!(visible_after < visible_before);
+    }
+
+    #[test]
+    fn test_set_capacity_larger_than_current() {
+        let mut history = History::new();
+        for i in 0..100 {
+            history.append(&format!("line {}", i));
+        }
+        assert_eq!(history.inner.len(), 100);
+
+        history.set_capacity(500);
+        assert_eq!(history.capacity, 500);
+        assert_eq!(history.inner.len(), 100);
+        assert_eq!(history.visible.len(), 100);
     }
 }

--- a/src/ui/reader_screen.rs
+++ b/src/ui/reader_screen.rs
@@ -441,6 +441,10 @@ impl UserInterface for ReaderScreen {
 
     fn set_tag_mask(&mut self, _mask: crate::model::TagMask) {}
 
+    fn set_history_capacity(&mut self, capacity: usize) {
+        self.history.set_capacity(capacity);
+    }
+
     fn set_status_line(&mut self, _line: usize, _info: String) -> Result<()> {
         Ok(())
     }

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -560,6 +560,10 @@ impl UserInterface for SplitScreen {
         self.setup().ok();
     }
 
+    fn set_history_capacity(&mut self, capacity: usize) {
+        self.history.set_capacity(capacity);
+    }
+
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()> {
         self.status_area.set_status_line(line, info);
         self.status_area.redraw_line(&mut self.screen, line)?;

--- a/src/ui/ui_wrapper.rs
+++ b/src/ui/ui_wrapper.rs
@@ -179,6 +179,10 @@ impl UserInterface for UiWrapper {
         self.screen.set_tag_mask(mask);
     }
 
+    fn set_history_capacity(&mut self, capacity: usize) {
+        self.screen.set_history_capacity(capacity);
+    }
+
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()> {
         self.screen.set_status_line(line, info)
     }

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -59,6 +59,7 @@ pub trait UserInterface {
     fn set_status_area_height(&mut self, height: u16) -> Result<()>;
     fn set_show_tags(&mut self, show: bool) -> Result<()>;
     fn set_tag_mask(&mut self, mask: TagMask);
+    fn set_history_capacity(&mut self, capacity: usize);
     fn set_status_line(&mut self, line: usize, info: String) -> Result<()>;
     fn flush(&mut self);
     fn width(&self) -> u16;


### PR DESCRIPTION
## Summary

Two related optimizations to address RSS growth from malloc fragmentation in long-running sessions:

1. **Incremental drain**: Change `History::drain()` from full `rebuild_visible()` to incremental visible line removal, avoiding repeated 16MB Vec allocation/deallocation cycles
2. **Configurable capacity**: Add `blight.history_capacity()` Lua API for runtime scrollback buffer size control (default: 32768 lines, backward compatible)

## Motivation

- `History::drain()` previously called `rebuild_visible()` which caused large Vec allocation/deallocation cycles
- malloc couldn't reclaim these fragments, leading to continuous RSS growth over time
- The hardcoded 32768 line capacity couldn't be adjusted for long-running sessions

## Changes

- `History::set_capacity()` - dynamic buffer resizing with line trimming
- `History::drain()` - incremental visible line removal instead of full rebuild
- `blight.history_capacity([capacity])` - new Lua API for getting/setting buffer size
- `Event::SetHistoryCapacity` - capacity change event propagation through all UI components
- 3 new unit tests for `set_capacity` functionality
- Updated help documentation

## Testing

- All 22 history-related tests pass
- `cargo fmt` clean
- `cargo clippy` clean (no new warnings from changed files)

## Usage

```lua
-- Get current capacity
local cap = blight.history_capacity()
print("Current capacity: " .. cap)

-- Set new capacity (e.g., 5000 lines for long-running sessions)
blight.history_capacity(5000)
```