### PR TITLE
Add help for command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ me to the word **blight** and here we are.
 - **Other/Alternative**  : Download source and run `cargo install --path .` from the project root
 - **Windows**            : No native windows support but Blightmud runs fine under WSL
 
+## Usage
+
+The following command line options are available when running Blightmud from a terminal:
+
+| Option | Description |
+|--------|-------------|
+| `-c`, `--connect <HOST:PORT>` | Connect to a server on startup |
+| `-t`, `--tls` | Use TLS when connecting (only applies with `--connect`) |
+| `-n`, `--no-verify` | Don't verify the cert for the TLS connection |
+| `-s`, `--script <PATH>` | Launch using the provided script instead of the defaults |
+| `-T`, `--tts` | Use the TTS system (only in builds compiled with TTS) |
+| `-w`, `--world <WORLD>` | Connect to a predefined world |
+| `-r`, `--reader-mode` | Force screen reader friendly mode |
+| `-V`, `--verbose` | Enable verbose logging |
+| `--no-update-check` | Skip checking for new Blightmud versions at startup |
+| `--codec <CODEC>` | Specify the codec to use for the MUD (eg. `UTF8`) |
+| `-v`, `--version` | Print version information and exit |
+| `-h`, `--help` | Print the help menu and exit |
+
+The authoritative list for your build is always available by running `blightmud --help`, and the same reference is available in-client via `/help command_line`.
+
 ## Compiling
 
 - Install rust

--- a/resources/help/command_line.md
+++ b/resources/help/command_line.md
@@ -1,0 +1,20 @@
+# Command line options
+
+Blightmud accepts the following options when started from the command line
+
+- `-c`, `--connect <HOST:PORT>`   Connect to a server on startup
+- `-t`, `--tls`                    Use TLS when connecting (only applies with `--connect`)
+- `-n`, `--no-verify`             Don't verify the cert for the TLS connection
+- `-s`, `--script <PATH>`         Launch using the provided script instead of the defaults
+- `-T`, `--tts`                   Use the TTS system (only in builds compiled with TTS)
+- `-w`, `--world <WORLD>`         Connect to a predefined world
+- `-r`, `--reader-mode`           Force screen reader friendly mode
+- `-V`, `--verbose`              Enable verbose logging
+- `--no-update-check`            Skip checking for new Blightmud versions at startup
+- `--codec <CODEC>`             Specify the codec to use for the MUD (eg. `UTF8`)
+- `-v`, `--version`             Print version information and exit
+- `-h`, `--help`               Print the help menu and exit
+
+The authoritative list of which options are available for your build is always available by running `blightmud --help`.
+
+The arguments Blightmud was started with can be read from within Lua via `core.command_line()`. See `/help core` for details.

--- a/resources/help/help.md
+++ b/resources/help/help.md
@@ -11,6 +11,7 @@ Available topics:
 - blight
 - changes
 - colors
+- command_line
 - config_scripts
 - core
 - fs

--- a/src/ui/help_handler.rs
+++ b/src/ui/help_handler.rs
@@ -203,6 +203,7 @@ fn load_files() -> HashMap<&'static str, &'static str> {
         "blight" => "blight.md",
         "bindings" => "bindings.md",
         "core" => "core.md",
+        "command_line" => "command_line.md",
         #[cfg(feature = "tts")]
         "tts" => "tts.md",
         #[cfg(not(feature = "tts"))]


### PR DESCRIPTION
Currently, there's no complete list of what command-line options are available; one would normally expect this to be in the README. So this PR adds help to the README and to the in-game help detailing what command-line options are available.
