### PR TITLE
Fix tab-aware output wrapping

### DIFF
--- a/src/tools/printable_chars.rs
+++ b/src/tools/printable_chars.rs
@@ -4,6 +4,16 @@ use std::str::{CharIndices, Chars};
 use unicode_width::UnicodeWidthChar;
 use vte::{Parser, Perform};
 
+const TAB_STOP_WIDTH: usize = 8;
+
+pub(crate) fn char_display_width(c: char, column: usize) -> usize {
+    if c == '\t' {
+        TAB_STOP_WIDTH - (column % TAB_STOP_WIDTH)
+    } else {
+        c.width().unwrap_or(0)
+    }
+}
+
 pub(crate) trait PrintableCharsIterator<'a> {
     fn printable_chars(&self) -> PrintableChars<'a>;
     fn printable_char_indices(&self) -> PrintableCharIndices<'a>;
@@ -26,14 +36,13 @@ impl<'a> PrintableCharsIterator<'a> for &'a str {
 
     fn display_width(&self) -> usize {
         self.printable_chars()
-            .map(|c: char| c.width().unwrap_or(0))
-            .sum()
+            .fold(0, |width, c| width + char_display_width(c, width))
     }
 
     fn byte_index_at_display_width(&self, target_width: usize) -> (usize, usize) {
         let mut width = 0;
         for (i, c) in self.printable_char_indices() {
-            let char_width = c.width().unwrap_or(0);
+            let char_width = char_display_width(c, width);
             if width + char_width > target_width {
                 return (i, width);
             }
@@ -56,6 +65,12 @@ impl Performer {
 impl Perform for Performer {
     fn print(&mut self, c: char) {
         self.c = Some(c)
+    }
+
+    fn execute(&mut self, byte: u8) {
+        if byte == b'\t' {
+            self.c = Some('\t');
+        }
     }
 }
 
@@ -193,6 +208,15 @@ mod test_printable_chars {
         // Wide chars with ANSI
         let ansi_wide = format!("{}中文{}", ANSI_RED, ANSI_OFF);
         assert_eq!(ansi_wide.as_str().display_width(), 4);
+
+        // Tabs advance to the next 8-column terminal tab stop
+        assert_eq!("\t".display_width(), 8);
+        assert_eq!("a\t".display_width(), 8);
+        assert_eq!("12345678\t".display_width(), 16);
+
+        // ANSI bytes do not change the column used to calculate tab stops
+        let ansi_tab = format!("{}abc\tdef{}", ANSI_RED, ANSI_OFF);
+        assert_eq!(ansi_tab.as_str().display_width(), 11);
     }
 
     #[test]
@@ -220,5 +244,10 @@ mod test_printable_chars {
         let (idx, width) = input.byte_index_at_display_width(6);
         assert_eq!(idx, 8); // 6 bytes for 中文 + 2 bytes for "te"
         assert_eq!(width, 6);
+
+        // A tab only fits when its next tab stop is within the target width
+        let input = "abc\tdef";
+        assert_eq!(input.byte_index_at_display_width(7), (3, 3));
+        assert_eq!(input.byte_index_at_display_width(8), (4, 8));
     }
 }

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -5,7 +5,7 @@ use mockall::automock;
 
 use crate::model::{Line, Regex, TagMask};
 use crate::tabs::TabInfo;
-use crate::tools::printable_chars::PrintableCharsIterator;
+use crate::tools::printable_chars::{char_display_width, PrintableCharsIterator};
 
 use anyhow::Result;
 
@@ -103,39 +103,59 @@ pub fn wrap_line(line: &str, width: usize, padding: usize) -> Vec<&str> {
         }
 
         let mut last_cut: usize = 0;
-        let mut last_space: usize = 0;
-        let mut print_length = 0;
-        let mut print_length_since_space = 0;
-        for (length, c) in line.printable_char_indices() {
-            // Keep track of printable line length
-            print_length += 1;
+        let printable_chars = line.printable_char_indices().collect::<Vec<_>>();
 
-            // Keep track of last occurence of <space> and how many printable
-            // characters followed it
-            print_length_since_space += 1;
-            if c == ' ' && print_length < width {
-                last_space = length;
-                print_length_since_space = 0;
-            }
+        while last_cut < line.len() {
+            let mut print_width = 0;
+            let mut last_space = None;
+            let mut did_cut = false;
+            let first_printable =
+                printable_chars.partition_point(|(byte_index, _)| *byte_index < last_cut);
 
-            // Split the line if it's print length reaches screen width
-            if print_length >= width {
-                // Cut from last space if there is any. Otherwise just cut.
-                if last_cut < last_space {
-                    lines.push(&line[last_cut..last_space]);
-                    print_length = print_length_since_space;
-                    last_cut = last_space + 1;
-                } else {
-                    lines.push(&line[last_cut..length + c.len_utf8()]);
-                    print_length = 0;
-                    last_cut = length + c.len_utf8();
+            for &(byte_index, c) in &printable_chars[first_printable..] {
+                let char_width = char_display_width(c, print_width);
+
+                if print_width + char_width > width {
+                    if let Some(space_index) = last_space {
+                        lines.push(&line[last_cut..space_index]);
+                        last_cut = space_index + 1;
+                    } else if byte_index > last_cut {
+                        lines.push(&line[last_cut..byte_index]);
+                        last_cut = byte_index;
+                    } else {
+                        let next_index = byte_index + c.len_utf8();
+                        lines.push(&line[last_cut..next_index]);
+                        last_cut = next_index;
+                    }
+                    did_cut = true;
+                    break;
+                }
+
+                print_width += char_width;
+                if c == ' ' && byte_index > last_cut && print_width < width {
+                    last_space = Some(byte_index);
+                }
+
+                if print_width == width {
+                    if let Some(space_index) = last_space {
+                        lines.push(&line[last_cut..space_index]);
+                        last_cut = space_index + 1;
+                    } else {
+                        let next_index = byte_index + c.len_utf8();
+                        lines.push(&line[last_cut..next_index]);
+                        last_cut = next_index;
+                    }
+                    did_cut = true;
+                    break;
                 }
             }
-        }
 
-        // Push the rest of the line if there is anything left
-        if last_cut < line.len() && !line[last_cut..].trim().is_empty() {
-            lines.push(&line[last_cut..]);
+            if !did_cut {
+                if !line[last_cut..].trim().is_empty() {
+                    lines.push(&line[last_cut..]);
+                }
+                break;
+            }
         }
     }
     lines
@@ -170,6 +190,19 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0], "hello");
         assert_eq!(lines[1], "world!!");
+    }
+
+    #[test]
+    fn test_wrap_line_with_tabs_at_different_columns() {
+        assert_eq!(wrap_line("\tab", 8, 0), vec!["\t", "ab"]);
+        assert_eq!(wrap_line("abc\tdef", 10, 0), vec!["abc\tde", "f"]);
+        assert_eq!(wrap_line("12345678\tz", 12, 0), vec!["12345678", "\tz"]);
+    }
+
+    #[test]
+    fn test_wrap_line_with_tabs_and_mixed_content() {
+        let line = "\x1b[31mab\t中x\x1b[0m";
+        assert_eq!(wrap_line(line, 10, 0), vec!["\x1b[31mab\t中", "x\x1b[0m"]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1473

## Summary

- surface horizontal tabs from the ANSI-aware VTE parser instead of dropping them from printable-width calculations
- calculate tab width from the current terminal column using 8-column tab stops
- wrap before content that would exceed the available display width while preserving the original tabs, Unicode text, and ANSI/OSC bytes
- add regressions for tabs at multiple columns, repeated tab stops, ANSI-colored text, and mixed wide-character content

## Reproduction

Before this change, `PrintableChars` discarded `\t` as a control byte. `wrap_line` also counted every remaining printable character as one column. As a result, a line such as `abc\tdef` was measured as six columns even though a terminal renders it as eleven columns, allowing output to cross the UI boundary and producing different truncation after redraw.

## Validation

- `cargo fmt -- --check`
- `cargo clippy --locked` (passes with 10 existing warnings outside this change)
- `cargo test --locked --all-features` (505 tests passed)
- `cargo build --release --locked --all-features`