### PR TITLE
Extract prompt layout into pure, testable modules

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -463,9 +463,6 @@ impl EventHandler {
                     lua_ctx.set_prompt_mask_content(updated_mask_table);
                     let mut prompt_input = self.session.prompt_input.lock().unwrap();
                     *prompt_input = command_buffer.get_masked_buffer();
-                    // Masked string, masked cursor. `get_pos` indexes the raw
-                    // buffer and would point into the wrong place as soon as a
-                    // mask inserts anything before the cursor.
                     screen.print_prompt_input(&prompt_input, command_buffer.get_masked_pos());
                 }
                 Ok(())
@@ -478,9 +475,6 @@ impl EventHandler {
                     }
                     let mut prompt_input = self.session.prompt_input.lock().unwrap();
                     *prompt_input = command_buffer.get_masked_buffer();
-                    // The mask was just cleared, so this is the identity — but
-                    // it is spelled the same way as the branch above so the
-                    // pairing stays obviously correct.
                     screen.print_prompt_input(&prompt_input, command_buffer.get_masked_pos());
                 }
                 Ok(())

--- a/src/event.rs
+++ b/src/event.rs
@@ -463,7 +463,10 @@ impl EventHandler {
                     lua_ctx.set_prompt_mask_content(updated_mask_table);
                     let mut prompt_input = self.session.prompt_input.lock().unwrap();
                     *prompt_input = command_buffer.get_masked_buffer();
-                    screen.print_prompt_input(&prompt_input, command_buffer.get_pos());
+                    // Masked string, masked cursor. `get_pos` indexes the raw
+                    // buffer and would point into the wrong place as soon as a
+                    // mask inserts anything before the cursor.
+                    screen.print_prompt_input(&prompt_input, command_buffer.get_masked_pos());
                 }
                 Ok(())
             }
@@ -475,7 +478,10 @@ impl EventHandler {
                     }
                     let mut prompt_input = self.session.prompt_input.lock().unwrap();
                     *prompt_input = command_buffer.get_masked_buffer();
-                    screen.print_prompt_input(&prompt_input, command_buffer.get_pos());
+                    // The mask was just cleared, so this is the identity — but
+                    // it is spelled the same way as the branch above so the
+                    // pairing stays obviously correct.
+                    screen.print_prompt_input(&prompt_input, command_buffer.get_masked_pos());
                 }
                 Ok(())
             }

--- a/src/model/prompt_mask.rs
+++ b/src/model/prompt_mask.rs
@@ -27,10 +27,6 @@ impl PromptMask {
                 return masked_buf.iter().collect();
             }
             masked_buf.splice(adjusted_idx..adjusted_idx, mask.chars());
-            // `masked_buf` is a `Vec<char>`, so the splice grew it by the
-            // mask's *character* count. `mask.len()` is its byte length, which
-            // only agrees for ASCII masks — any multi-byte mask coming from
-            // Lua pushed every subsequent index too far right.
             offset += mask.chars().count();
         }
 
@@ -40,20 +36,14 @@ impl PromptMask {
     /// Map a character index in the unmasked buffer to the equivalent index in
     /// the string [`Self::mask_buffer`] produces.
     ///
-    /// Without this the cursor and the text it points at come from different
-    /// coordinate spaces. A mask is not required to be an escape sequence —
-    /// Lua may supply any string, and printable masks are the documented use
-    /// (`"this is *important*, ok"`) — so the shift is real, not notional.
-    ///
-    /// `buf_len` is the unmasked buffer's character count, and exists so this
-    /// reproduces `mask_buffer`'s behaviour exactly: an out-of-range index
-    /// makes it stop applying masks altogether, so this must stop shifting at
-    /// the same point or the two disagree.
+    /// `buf_len` is the unmasked buffer's character count. `mask_buffer` stops
+    /// applying masks at the first out-of-range index, so the mapping must stop
+    /// shifting at the same point.
     pub fn masked_index(&self, unmasked_idx: usize, buf_len: usize) -> usize {
         let mut offset = 0usize;
         for (idx, mask) in self.iter() {
-            // The same cast `mask_buffer` performs, wrap included: a negative
-            // index becomes enormous and trips the bounds check there too.
+            // Same cast as `mask_buffer`: a negative index wraps and trips the
+            // bounds check.
             let idx = *idx as usize;
             if idx > buf_len {
                 break;
@@ -61,7 +51,7 @@ impl PromptMask {
             if idx > unmasked_idx {
                 break;
             }
-            // A mask anchored exactly at the cursor is spliced in *before* it,
+            // A mask anchored exactly at the cursor is spliced in before it,
             // so it pushes the cursor right.
             offset += mask.chars().count();
         }
@@ -189,9 +179,8 @@ mod test_prompt_mask {
         assert_eq!(res, "this is *important, ok");
     }
 
-    /// `offset` used to advance by the mask's byte length while the buffer it
-    /// indexes is a `Vec<char>`. A multi-byte mask therefore over-advanced,
-    /// and every mask after the first landed too far right.
+    /// The buffer being spliced is a `Vec<char>`, so the offset must advance
+    /// by the mask's character count, not its byte length.
     #[test]
     fn mask_with_multibyte_content_keeps_subsequent_indices_aligned() {
         let buf: Vec<char> = "this is important, ok".chars().collect();
@@ -215,24 +204,23 @@ mod test_prompt_mask {
     }
 
     /// The cursor index must be translated into the same coordinate space as
-    /// the string it indexes. Asserted against `mask_buffer` rather than
-    /// hand-written numbers, so the two cannot drift.
+    /// the string it indexes.
     #[test]
     fn masked_index_agrees_with_mask_buffer() {
         let buf: Vec<char> = "this is important, ok".chars().collect();
 
         for mask in [
-            // Printable masks, which shift real columns.
+            // printable
             PromptMask::from(BTreeMap::from([
                 (8, "*".to_string()),
                 (17, "*".to_string()),
             ])),
-            // Escape masks, which shift indices but no columns.
+            // escape sequences (zero columns)
             PromptMask::from(BTreeMap::from([
                 (0, "\x1b[44m".to_string()),
                 (21, "\x1b[0m".to_string()),
             ])),
-            // Multi-byte, multi-char masks.
+            // multi-byte, multi-char
             PromptMask::from(BTreeMap::from([(4, "»«".to_string())])),
             PromptMask::new(),
         ] {
@@ -244,10 +232,6 @@ mod test_prompt_mask {
                     mapped <= masked.len(),
                     "index {mapped} out of range for {masked:?}"
                 );
-                // The cursor must sit immediately before the same character it
-                // sat before in the unmasked buffer. A mask anchored exactly
-                // at the cursor belongs to its left — which is what makes the
-                // boundary `<=` rather than `<`.
                 if pos < buf.len() {
                     assert_eq!(
                         masked[mapped],
@@ -259,13 +243,10 @@ mod test_prompt_mask {
                 }
             }
 
-            // The end of the buffer maps to the end of the masked buffer.
             assert_eq!(mask.masked_index(buf.len(), buf.len()), masked.len());
         }
     }
 
-    /// With no mask the mapping is the identity, which is what keeps the
-    /// ordinary no-mask render path unchanged.
     #[test]
     fn masked_index_is_identity_without_a_mask() {
         let mask = PromptMask::new();
@@ -295,10 +276,8 @@ mod test_prompt_mask {
         assert_eq!(mask.masked_index(buf.len(), buf.len()), masked.len());
     }
 
-    /// Regression pin for PR #742: an out-of-range index must not panic. Note
-    /// the behaviour it pins is that the remaining masks are *silently
-    /// dropped* — the bounds check returns early rather than skipping the one
-    /// bad entry.
+    /// Regression pin for #742: an out-of-range index must not panic — the
+    /// remaining masks are silently dropped.
     #[test]
     fn mask_past_end_drops_remainder_without_panicking() {
         let buf: Vec<char> = "abc".chars().collect();
@@ -308,8 +287,7 @@ mod test_prompt_mask {
             (2, "#".to_string()),
         ]));
 
-        // BTreeMap iterates in key order, so 1 and 2 are applied and the
-        // out-of-range 99 ends the loop with nothing further applied.
+        // BTreeMap iterates in key order: 1 and 2 apply, 99 ends the loop.
         assert_eq!(mask.mask_buffer(&buf), "a*b#c");
     }
 }

--- a/src/model/prompt_mask.rs
+++ b/src/model/prompt_mask.rs
@@ -27,10 +27,45 @@ impl PromptMask {
                 return masked_buf.iter().collect();
             }
             masked_buf.splice(adjusted_idx..adjusted_idx, mask.chars());
-            offset += mask.len();
+            // `masked_buf` is a `Vec<char>`, so the splice grew it by the
+            // mask's *character* count. `mask.len()` is its byte length, which
+            // only agrees for ASCII masks — any multi-byte mask coming from
+            // Lua pushed every subsequent index too far right.
+            offset += mask.chars().count();
         }
 
         masked_buf.iter().collect()
+    }
+
+    /// Map a character index in the unmasked buffer to the equivalent index in
+    /// the string [`Self::mask_buffer`] produces.
+    ///
+    /// Without this the cursor and the text it points at come from different
+    /// coordinate spaces. A mask is not required to be an escape sequence —
+    /// Lua may supply any string, and printable masks are the documented use
+    /// (`"this is *important*, ok"`) — so the shift is real, not notional.
+    ///
+    /// `buf_len` is the unmasked buffer's character count, and exists so this
+    /// reproduces `mask_buffer`'s behaviour exactly: an out-of-range index
+    /// makes it stop applying masks altogether, so this must stop shifting at
+    /// the same point or the two disagree.
+    pub fn masked_index(&self, unmasked_idx: usize, buf_len: usize) -> usize {
+        let mut offset = 0usize;
+        for (idx, mask) in self.iter() {
+            // The same cast `mask_buffer` performs, wrap included: a negative
+            // index becomes enormous and trips the bounds check there too.
+            let idx = *idx as usize;
+            if idx > buf_len {
+                break;
+            }
+            if idx > unmasked_idx {
+                break;
+            }
+            // A mask anchored exactly at the cursor is spliced in *before* it,
+            // so it pushes the cursor right.
+            offset += mask.chars().count();
+        }
+        unmasked_idx + offset
     }
 
     pub fn to_table<'a>(&'a self, ctx: &'a Lua) -> LuaResult<LuaTable> {
@@ -152,5 +187,129 @@ mod test_prompt_mask {
         ]));
         let res = invalid_mask.mask_buffer(&buf);
         assert_eq!(res, "this is *important, ok");
+    }
+
+    /// `offset` used to advance by the mask's byte length while the buffer it
+    /// indexes is a `Vec<char>`. A multi-byte mask therefore over-advanced,
+    /// and every mask after the first landed too far right.
+    #[test]
+    fn mask_with_multibyte_content_keeps_subsequent_indices_aligned() {
+        let buf: Vec<char> = "this is important, ok".chars().collect();
+
+        // "»" is one char but two bytes; "«" likewise.
+        let mask = PromptMask::from(BTreeMap::from([
+            (8, "»".to_string()),
+            (17, "«".to_string()),
+        ]));
+
+        assert_eq!(mask.mask_buffer(&buf), "this is »important«, ok");
+    }
+
+    /// A mask anchored exactly at the end of the buffer is in bounds and must
+    /// be appended, not dropped.
+    #[test]
+    fn mask_at_exact_buffer_end_is_appended() {
+        let buf: Vec<char> = "abc".chars().collect();
+        let mask = PromptMask::from(BTreeMap::from([(3, "!".to_string())]));
+        assert_eq!(mask.mask_buffer(&buf), "abc!");
+    }
+
+    /// The cursor index must be translated into the same coordinate space as
+    /// the string it indexes. Asserted against `mask_buffer` rather than
+    /// hand-written numbers, so the two cannot drift.
+    #[test]
+    fn masked_index_agrees_with_mask_buffer() {
+        let buf: Vec<char> = "this is important, ok".chars().collect();
+
+        for mask in [
+            // Printable masks, which shift real columns.
+            PromptMask::from(BTreeMap::from([
+                (8, "*".to_string()),
+                (17, "*".to_string()),
+            ])),
+            // Escape masks, which shift indices but no columns.
+            PromptMask::from(BTreeMap::from([
+                (0, "\x1b[44m".to_string()),
+                (21, "\x1b[0m".to_string()),
+            ])),
+            // Multi-byte, multi-char masks.
+            PromptMask::from(BTreeMap::from([(4, "»«".to_string())])),
+            PromptMask::new(),
+        ] {
+            let masked: Vec<char> = mask.mask_buffer(&buf).chars().collect();
+
+            for pos in 0..=buf.len() {
+                let mapped = mask.masked_index(pos, buf.len());
+                assert!(
+                    mapped <= masked.len(),
+                    "index {mapped} out of range for {masked:?}"
+                );
+                // The cursor must sit immediately before the same character it
+                // sat before in the unmasked buffer. A mask anchored exactly
+                // at the cursor belongs to its left — which is what makes the
+                // boundary `<=` rather than `<`.
+                if pos < buf.len() {
+                    assert_eq!(
+                        masked[mapped],
+                        buf[pos],
+                        "cursor {pos} -> {mapped} points at the wrong character \
+                         in {:?}",
+                        masked.iter().collect::<String>()
+                    );
+                }
+            }
+
+            // The end of the buffer maps to the end of the masked buffer.
+            assert_eq!(mask.masked_index(buf.len(), buf.len()), masked.len());
+        }
+    }
+
+    /// With no mask the mapping is the identity, which is what keeps the
+    /// ordinary no-mask render path unchanged.
+    #[test]
+    fn masked_index_is_identity_without_a_mask() {
+        let mask = PromptMask::new();
+        for pos in 0..10 {
+            assert_eq!(mask.masked_index(pos, 9), pos);
+        }
+    }
+
+    /// `mask_buffer` stops applying masks at the first out-of-range index, so
+    /// the index map must stop shifting at exactly the same point.
+    #[test]
+    fn masked_index_stops_where_mask_buffer_stops() {
+        let buf: Vec<char> = "abc".chars().collect();
+        let mask = PromptMask::from(BTreeMap::from([
+            (1, "*".to_string()),
+            (99, "!".to_string()),
+            (2, "#".to_string()),
+        ]));
+
+        let masked: Vec<char> = mask.mask_buffer(&buf).chars().collect();
+        assert_eq!(masked.iter().collect::<String>(), "a*b#c");
+
+        for pos in 0..buf.len() {
+            let mapped = mask.masked_index(pos, buf.len());
+            assert_eq!(masked[mapped], buf[pos], "cursor {pos} -> {mapped}");
+        }
+        assert_eq!(mask.masked_index(buf.len(), buf.len()), masked.len());
+    }
+
+    /// Regression pin for PR #742: an out-of-range index must not panic. Note
+    /// the behaviour it pins is that the remaining masks are *silently
+    /// dropped* — the bounds check returns early rather than skipping the one
+    /// bad entry.
+    #[test]
+    fn mask_past_end_drops_remainder_without_panicking() {
+        let buf: Vec<char> = "abc".chars().collect();
+        let mask = PromptMask::from(BTreeMap::from([
+            (1, "*".to_string()),
+            (99, "!".to_string()),
+            (2, "#".to_string()),
+        ]));
+
+        // BTreeMap iterates in key order, so 1 and 2 are applied and the
+        // out-of-range 99 ends the loop with nothing further applied.
+        assert_eq!(mask.mask_buffer(&buf), "a*b#c");
     }
 }

--- a/src/ui/command.rs
+++ b/src/ui/command.rs
@@ -112,9 +112,8 @@ impl CommandBuffer {
     /// The cursor position expressed in the coordinate space of
     /// [`Self::get_masked_buffer`].
     ///
-    /// `get_pos` indexes the raw buffer, so pairing it with the masked buffer
-    /// hands the renderer two different coordinate spaces — the bug class that
-    /// produced #742. Use this whenever the masked buffer is what gets drawn.
+    /// `get_pos` indexes the raw buffer; use this whenever the masked buffer
+    /// is what gets drawn.
     pub fn get_masked_pos(&self) -> usize {
         self.prompt_mask
             .masked_index(self.cursor_pos, self.buffer.len())

--- a/src/ui/command.rs
+++ b/src/ui/command.rs
@@ -109,6 +109,17 @@ impl CommandBuffer {
         self.cursor_pos
     }
 
+    /// The cursor position expressed in the coordinate space of
+    /// [`Self::get_masked_buffer`].
+    ///
+    /// `get_pos` indexes the raw buffer, so pairing it with the masked buffer
+    /// hands the renderer two different coordinate spaces — the bug class that
+    /// produced #742. Use this whenever the masked buffer is what gets drawn.
+    pub fn get_masked_pos(&self) -> usize {
+        self.prompt_mask
+            .masked_index(self.cursor_pos, self.buffer.len())
+    }
+
     fn submit(&mut self) -> String {
         // If we have no buffer then swap in the last buffer
         if self.last_command_enabled && self.buffer.is_empty() {

--- a/src/ui/input_layout.rs
+++ b/src/ui/input_layout.rs
@@ -1,0 +1,384 @@
+//! Text arithmetic for the user input area: how a buffer divides into rows,
+//! where the cursor lands, and how tall the area wants to be.
+//!
+//! This is separated from [`super::split_screen`] for the same reason
+//! [`super::layout`] is: `SplitScreen::new` requires a real terminal, so
+//! anything computed inside it cannot be exercised in CI. Every piece of
+//! arithmetic lives here, where it is a pure function; the renderer stays a
+//! blitter.
+//!
+//! Two coordinate spaces meet here and must not be confused:
+//!
+//! * **byte** offsets, which is what [`rows`] returns, because they slice the
+//!   input directly;
+//! * **char** indices, which is what `CommandBuffer` counts in, and therefore
+//!   what [`cursor_row_col`] takes as `pos`.
+
+use std::ops::Range;
+
+use super::layout::{INPUT_HEIGHT_MAX, INPUT_HEIGHT_MIN};
+use super::user_interface::wrap_line_hard;
+use crate::tools::printable_chars::PrintableCharsIterator;
+
+/// Partition `input` into the visual rows it occupies in a `width`-column
+/// area, as byte ranges into `input`.
+///
+/// The ranges tile the input in order. `'\n'` characters are *not* part of any
+/// range — they are row separators, not content — so the ranges do not cover
+/// the whole string, but every non-newline byte belongs to exactly one.
+///
+/// Splitting on `'\n'` before wrapping is required, not stylistic:
+/// `PrintableChars` drives a vte parser whose `Performer` implements only
+/// `print`, so `'\n'` is a C0 control that is silently dropped. Measuring a
+/// buffer containing one would silently fuse two logical rows into one.
+pub fn rows(input: &str, width: u16) -> Vec<Range<usize>> {
+    let width = width.max(1) as usize;
+    let mut out: Vec<Range<usize>> = Vec::new();
+    let mut base = 0usize;
+
+    for segment in input.split('\n') {
+        let wrapped = wrap_line_hard(segment, width);
+        let last = wrapped.len() - 1; // `wrap_line_hard` never returns empty
+        let mut off = base;
+
+        for (i, row) in wrapped.iter().enumerate() {
+            out.push(off..off + row.len());
+            off += row.len();
+
+            // A logical row whose width is a nonzero exact multiple of the
+            // terminal width needs a trailing empty visual row. Without it a
+            // cursor sitting just past the last character addresses a row that
+            // does not exist — and this is precisely where a terminal puts it,
+            // since the cursor wraps to the next line rather than resting one
+            // column off the right edge.
+            if i == last && !row.is_empty() && row.display_width() >= width {
+                out.push(off..off);
+            }
+        }
+
+        base += segment.len() + 1; // `+ 1` for the '\n' that split consumed
+    }
+
+    out
+}
+
+/// Locate the flat **char** index `pos` as a `(row, column)` pair.
+///
+/// This is a lookup into [`rows`]'s partition rather than an independent
+/// `cumulative_width / width` calculation, and that matters:
+/// `byte_index_at_display_width` pushes a straddling double-width character
+/// forward onto the next row and leaves a hole in the one it left. A parallel
+/// reconstruction disagrees at every such hole by a full row, which renders
+/// the cursor a line away from the character it is editing.
+pub fn cursor_row_col(input: &str, pos: usize, width: u16) -> (u16, u16) {
+    let rows = rows(input, width);
+    let byte_off = char_to_byte(input, pos);
+
+    // The last row that starts at or before the cursor. `rows` is ordered and
+    // may contain empty ranges, so this is a scan rather than a search on
+    // containment — an empty range contains nothing.
+    let mut idx = 0;
+    for (i, row) in rows.iter().enumerate() {
+        if row.start <= byte_off {
+            idx = i;
+        } else {
+            break;
+        }
+    }
+
+    let row = &rows[idx];
+    let end = byte_off.clamp(row.start, row.end);
+    let before = &input[row.start..end];
+    let col = before.display_width();
+
+    (idx as u16, col as u16)
+}
+
+/// Byte offset of the `pos`-th character, saturating at the end of `input`.
+fn char_to_byte(input: &str, pos: usize) -> usize {
+    input
+        .char_indices()
+        .nth(pos)
+        .map(|(i, _)| i)
+        .unwrap_or(input.len())
+}
+
+/// How many rows the input area wants, given how many the content occupies.
+///
+/// `configured` is a *minimum*, not a fixed size: with auto-expand off it is
+/// the height, and with it on the area grows past it as content requires and
+/// shrinks back. One number, no mode enum.
+pub fn desired_height(row_count: usize, configured: u16, auto_expand: bool) -> u16 {
+    let configured = configured.clamp(INPUT_HEIGHT_MIN, INPUT_HEIGHT_MAX);
+    if auto_expand {
+        let rows = u16::try_from(row_count).unwrap_or(u16::MAX);
+        rows.clamp(configured, INPUT_HEIGHT_MAX)
+    } else {
+        configured
+    }
+}
+
+/// Which rows are on screen when the content is taller than the input area.
+///
+/// The cursor's row is always within the returned range; the window is pinned
+/// to the bottom of the content once it reaches the end.
+pub fn visible_rows(row_count: usize, cursor_row: usize, height: u16) -> Range<usize> {
+    let height = height.max(INPUT_HEIGHT_MIN) as usize;
+    if row_count <= height {
+        return 0..row_count;
+    }
+
+    let max_start = row_count - height;
+    let start = cursor_row.saturating_sub(height - 1).min(max_start);
+    start..start + height
+}
+
+#[cfg(test)]
+mod input_layout_test {
+    use super::*;
+
+    fn row_strs(input: &str, width: u16) -> Vec<&str> {
+        rows(input, width)
+            .into_iter()
+            .map(|r| &input[r])
+            .collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn plain_line_shorter_than_width_is_one_row() {
+        assert_eq!(row_strs("hello", 20), vec!["hello"]);
+    }
+
+    #[test]
+    fn empty_input_is_one_empty_row() {
+        assert_eq!(row_strs("", 20), vec![""]);
+    }
+
+    #[test]
+    fn newlines_start_new_rows_and_are_not_content() {
+        assert_eq!(row_strs("a\nb\nc", 20), vec!["a", "b", "c"]);
+        // A trailing newline opens an empty row the cursor can sit on.
+        assert_eq!(row_strs("a\n", 20), vec!["a", ""]);
+        // Consecutive newlines produce genuinely blank rows.
+        assert_eq!(row_strs("a\n\nb", 20), vec!["a", "", "b"]);
+    }
+
+    #[test]
+    fn long_line_wraps_losslessly() {
+        assert_eq!(row_strs("abcdefgh", 3), vec!["abc", "def", "gh"]);
+    }
+
+    /// The guard the plan calls out: at an exact multiple of the width there
+    /// must be a row for the cursor to wrap onto.
+    #[test]
+    fn exact_multiple_of_width_gets_a_trailing_empty_row() {
+        assert_eq!(row_strs("abc", 3), vec!["abc", ""]);
+        assert_eq!(row_strs("abcdef", 3), vec!["abc", "def", ""]);
+        // ...but only at the end of a logical row, not at every break.
+        assert_eq!(row_strs("abcd", 3), vec!["abc", "d"]);
+        // ...and not for an empty row, which is already the cursor's row.
+        assert_eq!(row_strs("", 3), vec![""]);
+    }
+
+    #[test]
+    fn wide_characters_wrap_by_display_width_not_char_count() {
+        // Each CJK glyph is two columns, so only two fit in five.
+        assert_eq!(row_strs("中文中文", 5), vec!["中文", "中文"]);
+    }
+
+    /// A glyph wider than the whole area must not spin the wrap loop. Each
+    /// glyph overflows its row by a column, and the trailing empty row still
+    /// appears — the cursor cannot rest in the overflowed column, so it needs
+    /// somewhere to go.
+    #[test]
+    fn glyph_wider_than_area_terminates() {
+        assert_eq!(row_strs("中文", 1), vec!["中", "文", ""]);
+        assert_eq!(cursor_row_col("中文", 2, 1), (2, 0));
+    }
+
+    /// Escape sequences occupy no columns and must not force a wrap.
+    #[test]
+    fn escapes_consume_no_columns() {
+        let input = "\x1b[31mabcde\x1b[0m";
+        assert_eq!(rows(input, 5).len(), 2); // content row + wrap row
+        assert_eq!(&input[rows(input, 5)[0].clone()], input);
+    }
+
+    /// Every byte except the row separators belongs to exactly one row, and
+    /// the rows are in order. This is the property the cursor depends on.
+    #[test]
+    fn rows_partition_the_input() {
+        for input in [
+            "",
+            "a",
+            "hello world",
+            "a\nb",
+            "a\n\nb\n",
+            "\n\n\n",
+            "中文test中文",
+            "\x1b[31mred\x1b[0m text",
+            "trailing   ",
+        ] {
+            for width in 1..=12u16 {
+                let rows = rows(input, width);
+                assert!(!rows.is_empty(), "{input:?} @ {width} produced no rows");
+
+                let mut expected = 0usize;
+                for row in &rows {
+                    assert!(row.start >= expected, "rows out of order in {input:?}");
+                    assert!(row.end >= row.start);
+                    assert!(row.end <= input.len());
+                    // Only a '\n' may be skipped between rows.
+                    if row.start > expected {
+                        assert_eq!(
+                            &input[expected..row.start],
+                            "\n",
+                            "unexpected gap in {input:?} @ {width}"
+                        );
+                    }
+                    expected = row.end;
+                }
+
+                let joined: String = rows.iter().map(|r| &input[r.clone()]).collect();
+                assert_eq!(
+                    joined,
+                    input.replace('\n', ""),
+                    "lost content in {input:?} @ {width}"
+                );
+            }
+        }
+    }
+
+    /// `cursor_row_col` is asserted against `rows()` rather than hand-written
+    /// expectations, so the two cannot drift apart. Every cursor position in
+    /// every buffer at every width must land on a row that exists, at a column
+    /// that row actually reaches.
+    #[test]
+    fn cursor_is_always_inside_a_real_row() {
+        for input in [
+            "",
+            "a",
+            "hello world",
+            "a\nb\nc",
+            "a\n\nb\n",
+            "中文test中文",
+            "\x1b[31mred\x1b[0m text",
+            "abc",
+            "abcdef",
+        ] {
+            for width in 1..=12u16 {
+                let rows = rows(input, width);
+                for pos in 0..=input.chars().count() {
+                    let (row, col) = cursor_row_col(input, pos, width);
+
+                    assert!(
+                        (row as usize) < rows.len(),
+                        "cursor row {row} out of range for {input:?} @ {width} pos {pos}"
+                    );
+
+                    let text = &input[rows[row as usize].clone()];
+                    assert!(
+                        col as usize <= text.display_width(),
+                        "cursor col {col} past end of row {row} ({text:?}) \
+                         for {input:?} @ {width} pos {pos}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn cursor_at_start_is_row_zero_column_zero() {
+        assert_eq!(cursor_row_col("hello", 0, 20), (0, 0));
+        assert_eq!(cursor_row_col("", 0, 20), (0, 0));
+    }
+
+    #[test]
+    fn cursor_tracks_logical_rows() {
+        let input = "ab\ncd";
+        assert_eq!(cursor_row_col(input, 2, 20), (0, 2)); // end of "ab"
+        assert_eq!(cursor_row_col(input, 3, 20), (1, 0)); // start of "cd"
+        assert_eq!(cursor_row_col(input, 5, 20), (1, 2)); // end of "cd"
+    }
+
+    #[test]
+    fn cursor_wraps_onto_the_trailing_empty_row() {
+        // "abc" exactly fills a 3-column area; the cursor after it belongs on
+        // the next row, which is why that row is generated at all.
+        assert_eq!(cursor_row_col("abc", 3, 3), (1, 0));
+        assert_eq!(cursor_row_col("abc", 2, 3), (0, 2));
+    }
+
+    #[test]
+    fn cursor_column_counts_display_width() {
+        // Two CJK glyphs are two chars but four columns.
+        assert_eq!(cursor_row_col("中文test", 2, 20), (0, 4));
+    }
+
+    /// A position past the end of the buffer must clamp, not panic.
+    #[test]
+    fn cursor_past_end_clamps() {
+        let (row, col) = cursor_row_col("abc", 99, 20);
+        assert_eq!((row, col), (0, 3));
+    }
+
+    #[test]
+    fn desired_height_is_the_configured_value_when_not_expanding() {
+        assert_eq!(desired_height(1, 3, false), 3);
+        assert_eq!(desired_height(9, 3, false), 3);
+        assert_eq!(desired_height(1, 1, false), 1);
+    }
+
+    #[test]
+    fn desired_height_grows_and_shrinks_when_expanding() {
+        assert_eq!(desired_height(1, 1, true), 1);
+        assert_eq!(desired_height(4, 1, true), 4);
+        // Never below the configured minimum...
+        assert_eq!(desired_height(1, 3, true), 3);
+        // ...and never above the hard maximum.
+        assert_eq!(desired_height(500, 1, true), INPUT_HEIGHT_MAX);
+        assert_eq!(desired_height(usize::MAX, 1, true), INPUT_HEIGHT_MAX);
+    }
+
+    #[test]
+    fn desired_height_clamps_a_nonsense_configuration() {
+        assert_eq!(desired_height(1, 0, false), INPUT_HEIGHT_MIN);
+        assert_eq!(desired_height(1, 500, false), INPUT_HEIGHT_MAX);
+    }
+
+    #[test]
+    fn all_rows_visible_when_they_fit() {
+        assert_eq!(visible_rows(3, 0, 5), 0..3);
+        assert_eq!(visible_rows(3, 2, 3), 0..3);
+        assert_eq!(visible_rows(0, 0, 3), 0..0);
+    }
+
+    #[test]
+    fn visible_window_follows_the_cursor() {
+        // 10 rows in a 3-row area.
+        assert_eq!(visible_rows(10, 0, 3), 0..3);
+        assert_eq!(visible_rows(10, 2, 3), 0..3);
+        assert_eq!(visible_rows(10, 3, 3), 1..4);
+        assert_eq!(visible_rows(10, 9, 3), 7..10);
+    }
+
+    /// The window must contain the cursor for every combination, or the user
+    /// types into a row they cannot see.
+    #[test]
+    fn visible_window_always_contains_the_cursor() {
+        for row_count in 1..30usize {
+            for height in 1..12u16 {
+                for cursor in 0..row_count {
+                    let window = visible_rows(row_count, cursor, height);
+                    assert!(
+                        window.contains(&cursor),
+                        "cursor {cursor} outside {window:?} \
+                         (rows {row_count}, height {height})"
+                    );
+                    assert!(window.end <= row_count);
+                    assert!(window.len() <= height as usize);
+                }
+            }
+        }
+    }
+}

--- a/src/ui/input_layout.rs
+++ b/src/ui/input_layout.rs
@@ -1,11 +1,9 @@
 //! Text arithmetic for the user input area: how a buffer divides into rows,
 //! where the cursor lands, and how tall the area wants to be.
 //!
-//! This is separated from [`super::split_screen`] for the same reason
-//! [`super::layout`] is: `SplitScreen::new` requires a real terminal, so
-//! anything computed inside it cannot be exercised in CI. Every piece of
-//! arithmetic lives here, where it is a pure function; the renderer stays a
-//! blitter.
+//! `SplitScreen::new` requires a real terminal, so anything computed inside
+//! it cannot be exercised in CI; the arithmetic lives here as pure functions
+//! instead.
 //!
 //! Two coordinate spaces meet here and must not be confused:
 //!
@@ -27,10 +25,9 @@ use crate::tools::printable_chars::PrintableCharsIterator;
 /// range — they are row separators, not content — so the ranges do not cover
 /// the whole string, but every non-newline byte belongs to exactly one.
 ///
-/// Splitting on `'\n'` before wrapping is required, not stylistic:
-/// `PrintableChars` drives a vte parser whose `Performer` implements only
-/// `print`, so `'\n'` is a C0 control that is silently dropped. Measuring a
-/// buffer containing one would silently fuse two logical rows into one.
+/// The input must be split on `'\n'` before wrapping: `PrintableChars`
+/// drives a vte parser whose `Performer` implements only `print`, so `'\n'`
+/// is silently dropped and two logical rows would measure as one.
 pub fn rows(input: &str, width: u16) -> Vec<Range<usize>> {
     let width = width.max(1) as usize;
     let mut out: Vec<Range<usize>> = Vec::new();
@@ -45,12 +42,9 @@ pub fn rows(input: &str, width: u16) -> Vec<Range<usize>> {
             out.push(off..off + row.len());
             off += row.len();
 
-            // A logical row whose width is a nonzero exact multiple of the
-            // terminal width needs a trailing empty visual row. Without it a
-            // cursor sitting just past the last character addresses a row that
-            // does not exist — and this is precisely where a terminal puts it,
-            // since the cursor wraps to the next line rather than resting one
-            // column off the right edge.
+            // A logical row exactly filling the width needs a trailing empty
+            // visual row: the cursor just past the last character wraps to the
+            // next line rather than resting one column off the right edge.
             if i == last && !row.is_empty() && row.display_width() >= width {
                 out.push(off..off);
             }
@@ -65,11 +59,9 @@ pub fn rows(input: &str, width: u16) -> Vec<Range<usize>> {
 /// Locate the flat **char** index `pos` as a `(row, column)` pair.
 ///
 /// This is a lookup into [`rows`]'s partition rather than an independent
-/// `cumulative_width / width` calculation, and that matters:
-/// `byte_index_at_display_width` pushes a straddling double-width character
-/// forward onto the next row and leaves a hole in the one it left. A parallel
-/// reconstruction disagrees at every such hole by a full row, which renders
-/// the cursor a line away from the character it is editing.
+/// `cumulative_width / width` calculation: `byte_index_at_display_width`
+/// pushes a straddling double-width character onto the next row, and a
+/// parallel reconstruction disagrees by a full row at every such hole.
 pub fn cursor_row_col(input: &str, pos: usize, width: u16) -> (u16, u16) {
     let rows = rows(input, width);
     let byte_off = char_to_byte(input, pos);
@@ -105,9 +97,9 @@ fn char_to_byte(input: &str, pos: usize) -> usize {
 
 /// How many rows the input area wants, given how many the content occupies.
 ///
-/// `configured` is a *minimum*, not a fixed size: with auto-expand off it is
+/// `configured` is a minimum, not a fixed size: with auto-expand off it is
 /// the height, and with it on the area grows past it as content requires and
-/// shrinks back. One number, no mode enum.
+/// shrinks back.
 pub fn desired_height(row_count: usize, configured: u16, auto_expand: bool) -> u16 {
     let configured = configured.clamp(INPUT_HEIGHT_MIN, INPUT_HEIGHT_MAX);
     if auto_expand {
@@ -168,8 +160,8 @@ mod input_layout_test {
         assert_eq!(row_strs("abcdefgh", 3), vec!["abc", "def", "gh"]);
     }
 
-    /// The guard the plan calls out: at an exact multiple of the width there
-    /// must be a row for the cursor to wrap onto.
+    /// At an exact multiple of the width there must be a row for the cursor
+    /// to wrap onto.
     #[test]
     fn exact_multiple_of_width_gets_a_trailing_empty_row() {
         assert_eq!(row_strs("abc", 3), vec!["abc", ""]);
@@ -186,10 +178,8 @@ mod input_layout_test {
         assert_eq!(row_strs("中文中文", 5), vec!["中文", "中文"]);
     }
 
-    /// A glyph wider than the whole area must not spin the wrap loop. Each
-    /// glyph overflows its row by a column, and the trailing empty row still
-    /// appears — the cursor cannot rest in the overflowed column, so it needs
-    /// somewhere to go.
+    /// A glyph wider than the whole area overflows its row rather than
+    /// spinning the wrap loop.
     #[test]
     fn glyph_wider_than_area_terminates() {
         assert_eq!(row_strs("中文", 1), vec!["中", "文", ""]);
@@ -249,10 +239,8 @@ mod input_layout_test {
         }
     }
 
-    /// `cursor_row_col` is asserted against `rows()` rather than hand-written
-    /// expectations, so the two cannot drift apart. Every cursor position in
-    /// every buffer at every width must land on a row that exists, at a column
-    /// that row actually reaches.
+    /// Every cursor position in every buffer at every width must land on a
+    /// row that exists, at a column that row actually reaches.
     #[test]
     fn cursor_is_always_inside_a_real_row() {
         for input in [
@@ -303,8 +291,8 @@ mod input_layout_test {
 
     #[test]
     fn cursor_wraps_onto_the_trailing_empty_row() {
-        // "abc" exactly fills a 3-column area; the cursor after it belongs on
-        // the next row, which is why that row is generated at all.
+        // "abc" exactly fills a 3-column area; the cursor after it belongs
+        // on the next row.
         assert_eq!(cursor_row_col("abc", 3, 3), (1, 0));
         assert_eq!(cursor_row_col("abc", 2, 3), (0, 2));
     }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,0 +1,290 @@
+//! Vertical screen layout arithmetic for [`super::SplitScreen`].
+//!
+//! `SplitScreen::new` needs a real terminal, so anything computed inside it
+//! cannot be exercised in CI. The row arithmetic lives here instead, as a pure
+//! function of the terminal height and the configured region sizes, so it can
+//! be tested directly.
+//!
+//! The screen is divided top to bottom:
+//!
+//! ```text
+//! 1                    ┐
+//! ..                   │ top area (`top_rows` rows, may be 0)
+//! top_rows             ┘
+//! output_start_line    ┐
+//! ..                   │ output / scroll region (DECSTBM)
+//! output_line          ┘
+//! mud_prompt_line        the MUD's own prompt (always exactly 1 row)
+//! ..                   ┐ status area (`status_height` rows, may be 0)
+//! ..                   ┘
+//! input_start_line     ┐
+//! ..                   │ user input area (`input_height` rows, at least 1)
+//! term_height          ┘
+//! ```
+
+/// The scroll region is programmed with DECSTBM (`CSI Pt ; Pb r`), which
+/// requires `Pt < Pb` — a region must span at least two rows. A terminal
+/// silently *discards* an out-of-range request rather than reporting an error,
+/// leaving whatever region was previously in effect; output written afterwards
+/// then scrolls the whole screen and drags the status and input areas with it.
+/// So a layout that cannot give the output region two rows is not renderable at
+/// all, and must be rejected rather than clamped.
+pub const MIN_OUTPUT_ROWS: u16 = 2;
+
+/// An input area is never zero rows — there would be nowhere to type.
+pub const INPUT_HEIGHT_MIN: u16 = 1;
+
+/// Upper bound on a user-requested input height, mirroring `STATUS_HEIGHT_MAX`.
+pub const INPUT_HEIGHT_MAX: u16 = 10;
+
+/// Absolute, 1-based terminal row numbers for each region boundary.
+///
+/// Produced only by [`ScreenLayout::compute`], which guarantees the invariants
+/// the renderer relies on — most importantly that the output region is valid to
+/// program as a scroll region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScreenLayout {
+    /// First row of the output/scroll region.
+    pub output_start_line: u16,
+    /// Last row of the output/scroll region.
+    pub output_line: u16,
+    /// The row carrying the MUD's own prompt.
+    pub mud_prompt_line: u16,
+    /// First row of the user input area.
+    pub input_start_line: u16,
+    /// Rows granted to the input area. May be less than requested.
+    pub input_height: u16,
+    /// Rows granted to the status area. May be less than requested.
+    pub status_height: u16,
+}
+
+impl ScreenLayout {
+    /// Divide a terminal `term_height` rows tall between the regions.
+    ///
+    /// `input_height` and `status_height` are *requests*. When the terminal is
+    /// too short to honour them, they are reduced in that order — the input
+    /// area shrinks toward [`INPUT_HEIGHT_MIN`] first, then the status area
+    /// toward zero — so that the output region keeps [`MIN_OUTPUT_ROWS`].
+    ///
+    /// Returns `None` when even the minimal layout does not fit, which the
+    /// caller must treat as "do not render", not as "render something".
+    pub fn compute(
+        term_height: u16,
+        top_rows: u16,
+        status_height: u16,
+        input_height: u16,
+    ) -> Option<Self> {
+        let output_start_line = top_rows.checked_add(1)?;
+
+        // Rows left for the output region, the MUD prompt, the status area and
+        // the input area once the top area has taken its share.
+        let budget = term_height.checked_sub(top_rows)?;
+
+        // The MUD prompt row, the minimum output region and the one row the
+        // input area is always entitled to are not negotiable; whatever remains
+        // is what the two configurable regions may share.
+        let fixed = MIN_OUTPUT_ROWS + 1 + INPUT_HEIGHT_MIN;
+        let spare = budget.checked_sub(fixed)?;
+
+        let mut input_height = input_height.clamp(INPUT_HEIGHT_MIN, INPUT_HEIGHT_MAX);
+        let mut status_height = status_height;
+
+        // Only the rows *beyond* the guaranteed minimum are drawn from `spare`.
+        if input_height - INPUT_HEIGHT_MIN + status_height > spare {
+            // Shrink the input area first, down to its minimum.
+            let overflow = input_height - INPUT_HEIGHT_MIN + status_height - spare;
+            let give = overflow.min(input_height - INPUT_HEIGHT_MIN);
+            input_height -= give;
+
+            // Then the status area, down to nothing.
+            let overflow = overflow - give;
+            status_height = status_height.saturating_sub(overflow);
+        }
+
+        // `spare` already reserved MIN_OUTPUT_ROWS, so the output region grows
+        // into whatever the configurable regions did not take.
+        let output_rows =
+            MIN_OUTPUT_ROWS + spare - (input_height - INPUT_HEIGHT_MIN) - status_height;
+
+        let output_line = output_start_line + output_rows - 1;
+        let mud_prompt_line = output_line + 1;
+        let input_start_line = mud_prompt_line + status_height + 1;
+
+        let layout = Self {
+            output_start_line,
+            output_line,
+            mud_prompt_line,
+            input_start_line,
+            input_height,
+            status_height,
+        };
+
+        debug_assert!(layout.is_scroll_region_valid());
+        debug_assert_eq!(
+            layout.input_start_line + layout.input_height - 1,
+            term_height,
+            "input area must end on the last terminal row"
+        );
+
+        Some(layout)
+    }
+
+    /// Whether the output region may be programmed with DECSTBM.
+    ///
+    /// [`Self::compute`] never produces a layout for which this is false; it is
+    /// exposed so the renderer can assert the invariant at the point of use.
+    pub fn is_scroll_region_valid(&self) -> bool {
+        self.output_line > self.output_start_line
+    }
+
+    /// Number of rows in the output region.
+    ///
+    /// `SplitScreen::output_range` is the production spelling of this; it reads
+    /// the boundaries this type produced, so the two cannot disagree.
+    #[cfg(test)]
+    pub fn output_rows(&self) -> u16 {
+        self.output_line - self.output_start_line + 1
+    }
+}
+
+#[cfg(test)]
+mod layout_test {
+    use super::*;
+
+    /// The arithmetic this module replaces, as it stood in `setup()`:
+    ///   output_line     = height - status - 2
+    ///   mud_prompt_line = height - status - 1
+    ///   prompt_line     = height
+    /// with `output_start_line = top_rows + 1`. A single-row input area must
+    /// still produce exactly those numbers.
+    #[test]
+    fn default_layout_matches_legacy_arithmetic() {
+        for height in [24_u16, 40, 50, 80] {
+            for top_rows in [1_u16, 2] {
+                for status in [0_u16, 1, 3, 5] {
+                    let layout = ScreenLayout::compute(height, top_rows, status, 1).unwrap();
+                    assert_eq!(layout.output_start_line, top_rows + 1);
+                    assert_eq!(layout.output_line, height - status - 2);
+                    assert_eq!(layout.mud_prompt_line, height - status - 1);
+                    assert_eq!(layout.input_start_line, height);
+                    assert_eq!(layout.status_height, status);
+                }
+            }
+        }
+    }
+
+    /// `height - status - 2` underflows once the status area and top rows
+    /// consume the terminal. Previously a debug-build panic.
+    #[test]
+    fn short_terminal_does_not_underflow() {
+        // Every one of these is a raw-subtraction panic in the old arithmetic.
+        assert!(ScreenLayout::compute(3, 1, 1, 1).is_none());
+        assert!(ScreenLayout::compute(2, 1, 0, 1).is_none());
+        assert!(ScreenLayout::compute(1, 1, 0, 1).is_none());
+        assert!(ScreenLayout::compute(0, 0, 0, 1).is_none());
+    }
+
+    /// `status_height` clamps to 5, so a 6-row terminal with a full status area
+    /// drove `self.height - height - PROMPT_HEIGHT` negative.
+    #[test]
+    fn status_height_five_on_six_row_terminal_leaves_output() {
+        let layout = ScreenLayout::compute(6, 1, 5, 1).unwrap();
+        assert!(layout.is_scroll_region_valid());
+        assert!(layout.output_rows() >= MIN_OUTPUT_ROWS);
+        // The status area gave up rows so the output region stayed valid.
+        assert!(layout.status_height < 5);
+    }
+
+    /// Precedence: the input area yields before the status area does.
+    #[test]
+    fn input_height_squeezes_before_status_starves() {
+        // 12 rows, 1 top row, status 3, input 5 -> needs 1+2+1+3+5 = 12, fits.
+        let layout = ScreenLayout::compute(12, 1, 3, 5).unwrap();
+        assert_eq!(layout.input_height, 5);
+        assert_eq!(layout.status_height, 3);
+
+        // One row tighter: the input area is what gives.
+        let layout = ScreenLayout::compute(11, 1, 3, 5).unwrap();
+        assert_eq!(layout.input_height, 4);
+        assert_eq!(layout.status_height, 3);
+
+        // Tighter still: input bottoms out at 1, then status starts yielding.
+        let layout = ScreenLayout::compute(8, 1, 3, 5).unwrap();
+        assert_eq!(layout.input_height, INPUT_HEIGHT_MIN);
+        assert_eq!(layout.status_height, 3);
+
+        let layout = ScreenLayout::compute(7, 1, 3, 5).unwrap();
+        assert_eq!(layout.input_height, INPUT_HEIGHT_MIN);
+        assert_eq!(layout.status_height, 2);
+    }
+
+    /// The regions must tile the terminal exactly, with no gap and no overlap,
+    /// for every layout `compute` is willing to return.
+    #[test]
+    fn regions_tile_the_terminal_exactly() {
+        for height in 0_u16..64 {
+            for top_rows in 0_u16..4 {
+                for status in 0_u16..6 {
+                    for input in 1_u16..12 {
+                        let Some(layout) = ScreenLayout::compute(height, top_rows, status, input)
+                        else {
+                            continue;
+                        };
+
+                        assert_eq!(layout.output_start_line, top_rows + 1);
+                        assert_eq!(layout.mud_prompt_line, layout.output_line + 1);
+                        assert_eq!(
+                            layout.input_start_line,
+                            layout.mud_prompt_line + layout.status_height + 1
+                        );
+                        assert_eq!(layout.input_start_line + layout.input_height - 1, height);
+
+                        assert!(layout.input_height >= INPUT_HEIGHT_MIN);
+                        assert!(layout.input_height <= input.max(INPUT_HEIGHT_MIN));
+                        assert!(layout.status_height <= status);
+                    }
+                }
+            }
+        }
+    }
+
+    /// The reason `compute` returns `Option` at all: a scroll region with
+    /// `bottom <= top` is discarded by the terminal, which is worse than not
+    /// rendering, because the previous region silently stays in force.
+    #[test]
+    fn scroll_region_is_never_emitted_with_bottom_le_top() {
+        for height in 0_u16..64 {
+            for top_rows in 0_u16..4 {
+                for status in 0_u16..6 {
+                    for input in 1_u16..12 {
+                        if let Some(layout) = ScreenLayout::compute(height, top_rows, status, input)
+                        {
+                            assert!(
+                                layout.is_scroll_region_valid(),
+                                "invalid scroll region {}..{} from ({height}, {top_rows}, {status}, {input})",
+                                layout.output_start_line,
+                                layout.output_line,
+                            );
+                            assert!(layout.output_rows() >= MIN_OUTPUT_ROWS);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// A request above the maximum is clamped, not rejected.
+    #[test]
+    fn input_height_clamps_to_max() {
+        let layout = ScreenLayout::compute(80, 1, 1, 500).unwrap();
+        assert_eq!(layout.input_height, INPUT_HEIGHT_MAX);
+    }
+
+    /// A zero request is raised to the minimum rather than leaving nowhere to
+    /// type.
+    #[test]
+    fn input_height_zero_is_raised_to_minimum() {
+        let layout = ScreenLayout::compute(80, 1, 1, 0).unwrap();
+        assert_eq!(layout.input_height, INPUT_HEIGHT_MIN);
+    }
+}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -138,9 +138,6 @@ impl ScreenLayout {
     }
 
     /// Number of rows in the output region.
-    ///
-    /// `SplitScreen::output_range` is the production spelling of this; it reads
-    /// the boundaries this type produced, so the two cannot disagree.
     #[cfg(test)]
     pub fn output_rows(&self) -> u16 {
         self.output_line - self.output_start_line + 1
@@ -151,14 +148,13 @@ impl ScreenLayout {
 mod layout_test {
     use super::*;
 
-    /// The arithmetic this module replaces, as it stood in `setup()`:
-    ///   output_line     = height - status - 2
-    ///   mud_prompt_line = height - status - 1
-    ///   prompt_line     = height
-    /// with `output_start_line = top_rows + 1`. A single-row input area must
-    /// still produce exactly those numbers.
+    /// A single-row input area must produce exactly:
+    ///   output_line      = height - status - 2
+    ///   mud_prompt_line  = height - status - 1
+    ///   input_start_line = height
+    /// with `output_start_line = top_rows + 1`.
     #[test]
-    fn default_layout_matches_legacy_arithmetic() {
+    fn single_row_input_layout_boundaries() {
         for height in [24_u16, 40, 50, 80] {
             for top_rows in [1_u16, 2] {
                 for status in [0_u16, 1, 3, 5] {
@@ -173,19 +169,17 @@ mod layout_test {
         }
     }
 
-    /// `height - status - 2` underflows once the status area and top rows
-    /// consume the terminal. Previously a debug-build panic.
+    /// A terminal too short for even the minimal layout is rejected.
     #[test]
     fn short_terminal_does_not_underflow() {
-        // Every one of these is a raw-subtraction panic in the old arithmetic.
         assert!(ScreenLayout::compute(3, 1, 1, 1).is_none());
         assert!(ScreenLayout::compute(2, 1, 0, 1).is_none());
         assert!(ScreenLayout::compute(1, 1, 0, 1).is_none());
         assert!(ScreenLayout::compute(0, 0, 0, 1).is_none());
     }
 
-    /// `status_height` clamps to 5, so a 6-row terminal with a full status area
-    /// drove `self.height - height - PROMPT_HEIGHT` negative.
+    /// A 6-row terminal with a full status area must still leave a valid
+    /// output region.
     #[test]
     fn status_height_five_on_six_row_terminal_leaves_output() {
         let layout = ScreenLayout::compute(6, 1, 5, 1).unwrap();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,6 +20,8 @@ mod command;
 mod headless_screen;
 mod help_handler;
 mod history;
+mod input_layout;
+mod layout;
 mod reader_screen;
 mod scroll_data;
 mod split_screen;

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -1,4 +1,6 @@
 use super::history::History;
+use super::input_layout;
+use super::layout::{ScreenLayout, INPUT_HEIGHT_MIN};
 use super::scroll_data::ScrollData;
 use super::top_area::{
     self, row_names, TopArea, TopPrefix, TopPrefixStyle, TopRenderContext, TopRowBody,
@@ -146,6 +148,15 @@ pub struct SplitScreen {
     prompt_line: u16,
     status_area: StatusArea,
     cursor_prompt_pos: u16,
+    /// Cursor row *within* the input area, counted from `prompt_line`. Always
+    /// zero while the input area is one row tall.
+    cursor_prompt_row: u16,
+    /// Rows granted to the user input area. Pinned at [`INPUT_HEIGHT_MIN`]
+    /// until the height plumbing lands; the multi-row render path below is
+    /// therefore compiled but not yet reachable.
+    input_height: u16,
+    /// Whether the input area grows past `input_height` as content requires.
+    input_auto_expand: bool,
     history: History,
     scroll_data: ScrollData,
     connection: Option<String>,
@@ -181,9 +192,6 @@ impl UserInterface for SplitScreen {
         if width > 0 && height > 0 {
             self.width = width;
             self.height = height;
-            self.output_line = height - self.status_area.height() - 2;
-            self.mud_prompt_line = height - self.status_area.height() - 1;
-            self.prompt_line = height;
 
             // Reconcile built-in top row config with current settings.
             // Each visible row consumes one screen line above the output
@@ -218,7 +226,29 @@ impl UserInterface for SplitScreen {
                     row.visible = !hide_topbar;
                 }
             }
-            self.output_start_line = self.top_area.visible_row_count() + 1;
+            // The top area's height is only known once the rows above have
+            // been reconciled, and it is an input to every other boundary.
+            let layout = ScreenLayout::compute(
+                height,
+                self.top_area.visible_row_count(),
+                self.status_area.height(),
+                INPUT_HEIGHT_MIN,
+            )
+            .ok_or(TerminalSizeError)?;
+
+            self.output_start_line = layout.output_start_line;
+            self.output_line = layout.output_line;
+            self.mud_prompt_line = layout.mud_prompt_line;
+            self.prompt_line = layout.input_start_line;
+
+            // The layout may have taken rows away from the status area to keep
+            // the output region renderable.
+            if layout.status_height != self.status_area.height() {
+                self.status_area
+                    .set_height(layout.status_height, self.mud_prompt_line + 1);
+            } else {
+                self.status_area.update_pos(self.mud_prompt_line + 1);
+            }
 
             write!(
                 self.screen,
@@ -297,8 +327,30 @@ impl UserInterface for SplitScreen {
         self.prompt_input = input.to_string();
         self.prompt_input_pos = pos;
 
-        // Calculate display width up to cursor position
-        let (byte_idx_at_cursor, _) = input.byte_index_at_display_width(pos);
+        if self.input_height > INPUT_HEIGHT_MIN {
+            self.print_prompt_input_rows(input, pos);
+            return;
+        }
+
+        // Single-row rendering is kept exactly as it was, horizontal `>`
+        // scrolling included, rather than being folded into the row path. The
+        // two solve different problems — one scrolls a viewport sideways, the
+        // other wraps — and this is the path every user is on today.
+        self.cursor_prompt_row = 0;
+
+        // Calculate display width up to cursor position.
+        //
+        // `pos` is a character index, so it is converted by counting
+        // characters. It used to be handed to `byte_index_at_display_width`,
+        // which reads its argument as a column count — the two agree only
+        // while every character is one column wide, so a CJK glyph anywhere
+        // left of the cursor dragged the cursor backwards by one column per
+        // glyph.
+        let byte_idx_at_cursor = input
+            .char_indices()
+            .nth(pos)
+            .map(|(idx, _)| idx)
+            .unwrap_or(input.len());
         let mut cursor_display_pos = (&input[..byte_idx_at_cursor]).display_width();
 
         let mut input = input;
@@ -332,10 +384,14 @@ impl UserInterface for SplitScreen {
         self.cursor_prompt_pos = cursor_display_pos as u16 + cursor_offset;
 
         let wrap_indicator = if wrapped { ">" } else { "" };
+        // The `cursor::Save`/`Restore` pair that used to bracket this write is
+        // gone. DECSC provides one save slot per screen buffer, so saving here
+        // destroyed the position `setup()` deliberately stored — and the
+        // restore was unobservable anyway, because `goto_prompt()` overwrites
+        // the cursor position on the very next byte.
         write!(
             self.screen,
-            "{}{}{}{}{}{}{}{}{}{}",
-            termion::cursor::Save,
+            "{}{}{}{}{}{}{}{}",
             termion::cursor::Goto(1, self.prompt_line),
             Fg(termion::color::Reset),
             Bg(termion::color::Reset),
@@ -343,7 +399,6 @@ impl UserInterface for SplitScreen {
             termion::clear::CurrentLine,
             wrap_indicator,
             input,
-            termion::cursor::Restore,
             self.goto_prompt(),
         )
         .unwrap();
@@ -712,25 +767,31 @@ impl SplitScreen {
     pub fn new(screen: Box<dyn Write>, history: History) -> Result<Self> {
         let (width, height) = termion::terminal_size()?;
 
-        let output_start_line = 2;
+        // `setup()` recomputes this from the live top-area row count before
+        // anything is drawn; the initial guess only has to be self-consistent.
+        // Deriving it here from the same function `setup()` uses is what keeps
+        // the two from drifting apart.
+        let top_rows = TopArea::new_default().visible_row_count();
         let status_area_height = 1;
-        let output_line = height - status_area_height - 2;
-        let mud_prompt_line = height - status_area_height - 1;
-        let prompt_line = height;
+        let layout = ScreenLayout::compute(height, top_rows, status_area_height, INPUT_HEIGHT_MIN)
+            .ok_or(TerminalSizeError)?;
 
-        let status_area = StatusArea::new(status_area_height, mud_prompt_line + 1, width);
+        let status_area = StatusArea::new(layout.status_height, layout.mud_prompt_line + 1, width);
 
         Ok(Self {
             screen,
             width,
             height,
-            output_start_line,
-            output_line,
-            mud_prompt_line,
+            output_start_line: layout.output_start_line,
+            output_line: layout.output_line,
+            mud_prompt_line: layout.mud_prompt_line,
             mud_prompt: Line::from(""),
             status_area,
-            prompt_line,
+            prompt_line: layout.input_start_line,
             cursor_prompt_pos: 1,
+            cursor_prompt_row: 0,
+            input_height: layout.input_height,
+            input_auto_expand: false,
             history,
             scroll_data: ScrollData::new(),
             connection: None,
@@ -775,6 +836,55 @@ impl SplitScreen {
             )
             .unwrap();
         }
+    }
+
+    /// The height the input area wants for `row_count` rows of content.
+    ///
+    /// With auto-expand off this is just the configured height, which is why
+    /// wiring it up now changes nothing.
+    fn effective_input_height(&self, row_count: usize) -> u16 {
+        input_layout::desired_height(row_count, self.input_height, self.input_auto_expand)
+    }
+
+    /// Paint the input area as wrapped rows. Used when the area is taller than
+    /// one row; `print_prompt_input` keeps the horizontal-scroll path for the
+    /// single-row case.
+    fn print_prompt_input_rows(&mut self, input: &str, pos: usize) {
+        let rows = input_layout::rows(input, self.width);
+        let (cursor_row, cursor_col) = input_layout::cursor_row_col(input, pos, self.width);
+        let height = self.effective_input_height(rows.len());
+        let window = input_layout::visible_rows(rows.len(), cursor_row as usize, height);
+
+        self.cursor_prompt_row = (cursor_row as usize).saturating_sub(window.start) as u16;
+        self.cursor_prompt_pos = cursor_col + 1;
+
+        let mut out = String::new();
+        // Erase by *region* extent, not content extent. Terminal cells persist
+        // until something overwrites them, so a clear loop bounded by the row
+        // count never visits the rows the input just gave up — backspacing
+        // past a wrap or submitting would leave the old text sitting below the
+        // live input.
+        for offset in 0..height {
+            let text = window
+                .start
+                .checked_add(offset as usize)
+                .filter(|i| *i < window.end)
+                .map(|i| &input[rows[i].clone()])
+                .unwrap_or("");
+
+            out.push_str(&format!(
+                "{}{}{}{}{}{}",
+                termion::cursor::Goto(1, self.prompt_line + offset),
+                Fg(termion::color::Reset),
+                Bg(termion::color::Reset),
+                termion::style::Reset,
+                termion::clear::CurrentLine,
+                text,
+            ));
+        }
+        out.push_str(&self.goto_prompt());
+
+        write!(self.screen, "{out}").unwrap();
     }
 
     fn clear_prompt(&mut self) {
@@ -832,7 +942,10 @@ impl SplitScreen {
     fn goto_prompt(&self) -> String {
         format!(
             "{}",
-            termion::cursor::Goto(self.cursor_prompt_pos, self.prompt_line),
+            termion::cursor::Goto(
+                self.cursor_prompt_pos,
+                self.prompt_line + self.cursor_prompt_row
+            ),
         )
     }
 
@@ -841,17 +954,25 @@ impl SplitScreen {
         if self.scroll_range() < self.output_range() {
             self.scroll_data.split = true;
             let scroll_range = self.scroll_range();
+
+            // The divider sits directly below the frozen scrollback rows; the
+            // live region starts on the row after it. Spelling that as a
+            // literal `3` was only correct while `output_start_line` was
+            // pinned at 2 — it moves as soon as a top row is hidden or the tab
+            // indicator appears, putting the divider *inside* the scroll
+            // region, where the next MUD line scrolls it away.
+            let divider_line = scroll_range + self.output_start_line;
             write!(self.screen, "{ResetScrollRegion}")?;
             write!(
                 self.screen,
                 "{}{}",
-                ScrollRegion(scroll_range + 3, self.output_line),
+                ScrollRegion(divider_line + 1, self.output_line),
                 DisableOriginMode
             )?;
             write!(
                 self.screen,
                 "{}{}{:━<4$}{}",
-                cursor::Goto(1, scroll_range + self.output_start_line),
+                cursor::Goto(1, divider_line),
                 color::Fg(color::Green),
                 "━ (scroll) ",
                 color::Fg(color::Reset),
@@ -902,9 +1023,18 @@ impl SplitScreen {
         Ok(())
     }
 
+    /// Rows of frozen scrollback shown while scrolling.
+    ///
+    /// The split reserves `SCROLL_LIVE_BUFFER_SIZE` rows at the bottom of the
+    /// output region for live output, so it is only possible when the output
+    /// region has more rows than that. The old guard tested the *terminal*
+    /// height instead, which says nothing about how many rows the output
+    /// region was actually left with once the top, status and input areas took
+    /// their share — so the subtraction below wrapped to ~65530 and was handed
+    /// straight to DECSTBM.
     fn scroll_range(&self) -> u16 {
-        if self.scroll_data.allow_split && self.height > SCROLL_LIVE_BUFFER_SIZE * 2 {
-            self.output_line - self.output_start_line - SCROLL_LIVE_BUFFER_SIZE + 1
+        if self.scroll_data.allow_split && self.output_range() > SCROLL_LIVE_BUFFER_SIZE {
+            self.output_range() - SCROLL_LIVE_BUFFER_SIZE
         } else {
             self.output_range()
         }
@@ -918,6 +1048,7 @@ impl SplitScreen {
 #[cfg(test)]
 mod screen_test {
     use super::*;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn test_append_history() {
@@ -1095,5 +1226,174 @@ mod screen_test {
             .collect::<String>();
 
         assert_eq!(clean_output, "━ this t ━");
+    }
+
+    // ---- Input area rendering -------------------------------------------
+    //
+    // `SplitScreen::new` needs a real terminal, so these build the struct
+    // directly against a capturing writer. That is the only way to get the
+    // render path itself under test rather than testing a reimplementation of
+    // it beside the code that ships.
+
+    #[derive(Clone)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A screen `width` columns wide with an `input_height`-row input area
+    /// starting at row `prompt_line`, plus the buffer it renders into.
+    fn test_screen(width: u16, input_height: u16) -> (SplitScreen, Arc<Mutex<Vec<u8>>>) {
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let height = 24;
+        let layout = ScreenLayout::compute(height, 2, 1, input_height).unwrap();
+        let screen = SplitScreen {
+            screen: Box::new(SharedBuf(sink.clone())),
+            width,
+            height,
+            output_start_line: layout.output_start_line,
+            output_line: layout.output_line,
+            mud_prompt_line: layout.mud_prompt_line,
+            mud_prompt: Line::from(""),
+            status_area: StatusArea::new(layout.status_height, layout.mud_prompt_line + 1, width),
+            prompt_line: layout.input_start_line,
+            cursor_prompt_pos: 1,
+            cursor_prompt_row: 0,
+            input_height: layout.input_height,
+            input_auto_expand: false,
+            history: History::new(),
+            scroll_data: ScrollData::new(),
+            connection: None,
+            tags: HashSet::new(),
+            prompt_input: String::new(),
+            prompt_input_pos: 0,
+            show_tags: false,
+            tag_mask: TagMask::default(),
+            top_area: TopArea::new_default(),
+            tabs_metadata: Vec::new(),
+            inline_tabs_setting: false,
+        };
+        (screen, sink)
+    }
+
+    fn rendered(sink: &Arc<Mutex<Vec<u8>>>) -> String {
+        String::from_utf8(sink.lock().unwrap().clone()).unwrap()
+    }
+
+    /// The default configuration must not take the row path at all — this is
+    /// the guard that the refactor left every existing user where they were.
+    #[test]
+    fn single_row_input_keeps_the_horizontal_scroll_path() {
+        let (mut screen, sink) = test_screen(20, 1);
+        assert_eq!(screen.input_height, INPUT_HEIGHT_MIN);
+
+        // Longer than the width, with the cursor at the end: the single-row
+        // path scrolls sideways behind a '>' rather than wrapping.
+        let input = "abcdefghijklmnopqrstuvwxyz";
+        screen.print_prompt_input(input, input.chars().count());
+
+        let out = rendered(&sink);
+        assert!(
+            out.contains('>'),
+            "expected the scroll indicator in {out:?}"
+        );
+        assert_eq!(screen.cursor_prompt_row, 0);
+        // Everything lands on the one input row.
+        assert_eq!(
+            out.matches(&format!("{}", termion::cursor::Goto(1, screen.prompt_line)))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn multi_row_input_wraps_instead_of_scrolling() {
+        let (mut screen, sink) = test_screen(10, 3);
+        let input = "abcdefghijklmno"; // 15 chars over 10 columns -> 2 rows
+        screen.print_prompt_input(input, input.chars().count());
+
+        let out = rendered(&sink);
+        assert!(!out.contains('>'), "row path must not scroll sideways");
+        assert!(out.contains("abcdefghij"));
+        assert!(out.contains("klmno"));
+        assert_eq!(screen.cursor_prompt_row, 1);
+        assert_eq!(screen.cursor_prompt_pos, 6); // 5 columns in, 1-based
+    }
+
+    /// Newlines start new rows rather than being emitted as raw control
+    /// characters.
+    #[test]
+    fn multi_row_input_renders_logical_rows() {
+        let (mut screen, sink) = test_screen(20, 3);
+        screen.print_prompt_input("one\ntwo", 7);
+
+        let out = rendered(&sink);
+        assert!(out.contains("one"));
+        assert!(out.contains("two"));
+        assert_eq!(screen.cursor_prompt_row, 1);
+        assert_eq!(screen.cursor_prompt_pos, 4);
+    }
+
+    /// The input area is erased by region extent. A content-bounded clear
+    /// leaves the rows the input just gave up still showing their old text.
+    #[test]
+    fn every_input_row_is_erased_even_when_content_shrinks() {
+        let (mut screen, sink) = test_screen(20, 3);
+
+        // Three rows of content, then one.
+        screen.print_prompt_input("a\nb\nc", 5);
+        sink.lock().unwrap().clear();
+        screen.print_prompt_input("a", 1);
+
+        let out = rendered(&sink);
+        for offset in 0..3 {
+            let goto = format!("{}", termion::cursor::Goto(1, screen.prompt_line + offset));
+            assert!(
+                out.contains(&goto),
+                "row {offset} was never visited, so its old content survives"
+            );
+        }
+        assert_eq!(
+            out.matches(&format!("{}", termion::clear::CurrentLine))
+                .count(),
+            3,
+            "each of the three rows must be cleared"
+        );
+    }
+
+    /// Content taller than the area scrolls within it, and the cursor stays
+    /// inside the visible window.
+    #[test]
+    fn content_taller_than_the_area_scrolls_within_it() {
+        let (mut screen, sink) = test_screen(20, 2);
+        let input = "r0\nr1\nr2\nr3";
+        screen.print_prompt_input(input, input.chars().count());
+
+        let out = rendered(&sink);
+        assert!(out.contains("r2") && out.contains("r3"));
+        assert!(!out.contains("r0"), "row 0 has scrolled out of the area");
+        assert!(screen.cursor_prompt_row < screen.input_height);
+    }
+
+    /// `goto_prompt` addresses the cursor's row within the area, not always
+    /// the first row — every other draw path appends it, so a wrong row here
+    /// would misplace the cursor after any redraw.
+    #[test]
+    fn goto_prompt_targets_the_cursor_row() {
+        let (mut screen, _sink) = test_screen(20, 3);
+        screen.print_prompt_input("a\nb\nc", 5);
+
+        assert_eq!(screen.cursor_prompt_row, 2);
+        assert_eq!(
+            screen.goto_prompt(),
+            format!("{}", termion::cursor::Goto(2, screen.prompt_line + 2))
+        );
     }
 }

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -332,20 +332,11 @@ impl UserInterface for SplitScreen {
             return;
         }
 
-        // Single-row rendering is kept exactly as it was, horizontal `>`
-        // scrolling included, rather than being folded into the row path. The
-        // two solve different problems — one scrolls a viewport sideways, the
-        // other wraps — and this is the path every user is on today.
+        // Single-row path: scrolls horizontally behind a '>' instead of
+        // wrapping.
         self.cursor_prompt_row = 0;
 
-        // Calculate display width up to cursor position.
-        //
-        // `pos` is a character index, so it is converted by counting
-        // characters. It used to be handed to `byte_index_at_display_width`,
-        // which reads its argument as a column count — the two agree only
-        // while every character is one column wide, so a CJK glyph anywhere
-        // left of the cursor dragged the cursor backwards by one column per
-        // glyph.
+        // `pos` is a character index, not a display column.
         let byte_idx_at_cursor = input
             .char_indices()
             .nth(pos)
@@ -384,11 +375,6 @@ impl UserInterface for SplitScreen {
         self.cursor_prompt_pos = cursor_display_pos as u16 + cursor_offset;
 
         let wrap_indicator = if wrapped { ">" } else { "" };
-        // The `cursor::Save`/`Restore` pair that used to bracket this write is
-        // gone. DECSC provides one save slot per screen buffer, so saving here
-        // destroyed the position `setup()` deliberately stored — and the
-        // restore was unobservable anyway, because `goto_prompt()` overwrites
-        // the cursor position on the very next byte.
         write!(
             self.screen,
             "{}{}{}{}{}{}{}{}",
@@ -769,8 +755,6 @@ impl SplitScreen {
 
         // `setup()` recomputes this from the live top-area row count before
         // anything is drawn; the initial guess only has to be self-consistent.
-        // Deriving it here from the same function `setup()` uses is what keeps
-        // the two from drifting apart.
         let top_rows = TopArea::new_default().visible_row_count();
         let status_area_height = 1;
         let layout = ScreenLayout::compute(height, top_rows, status_area_height, INPUT_HEIGHT_MIN)
@@ -839,9 +823,7 @@ impl SplitScreen {
     }
 
     /// The height the input area wants for `row_count` rows of content.
-    ///
-    /// With auto-expand off this is just the configured height, which is why
-    /// wiring it up now changes nothing.
+    /// With auto-expand off this is just the configured height.
     fn effective_input_height(&self, row_count: usize) -> u16 {
         input_layout::desired_height(row_count, self.input_height, self.input_auto_expand)
     }
@@ -955,12 +937,8 @@ impl SplitScreen {
             self.scroll_data.split = true;
             let scroll_range = self.scroll_range();
 
-            // The divider sits directly below the frozen scrollback rows; the
-            // live region starts on the row after it. Spelling that as a
-            // literal `3` was only correct while `output_start_line` was
-            // pinned at 2 — it moves as soon as a top row is hidden or the tab
-            // indicator appears, putting the divider *inside* the scroll
-            // region, where the next MUD line scrolls it away.
+            // The divider sits directly below the frozen scrollback rows;
+            // the live region starts on the row after it.
             let divider_line = scroll_range + self.output_start_line;
             write!(self.screen, "{ResetScrollRegion}")?;
             write!(
@@ -1027,11 +1005,7 @@ impl SplitScreen {
     ///
     /// The split reserves `SCROLL_LIVE_BUFFER_SIZE` rows at the bottom of the
     /// output region for live output, so it is only possible when the output
-    /// region has more rows than that. The old guard tested the *terminal*
-    /// height instead, which says nothing about how many rows the output
-    /// region was actually left with once the top, status and input areas took
-    /// their share — so the subtraction below wrapped to ~65530 and was handed
-    /// straight to DECSTBM.
+    /// region has more rows than that.
     fn scroll_range(&self) -> u16 {
         if self.scroll_data.allow_split && self.output_range() > SCROLL_LIVE_BUFFER_SIZE {
             self.output_range() - SCROLL_LIVE_BUFFER_SIZE
@@ -1231,9 +1205,7 @@ mod screen_test {
     // ---- Input area rendering -------------------------------------------
     //
     // `SplitScreen::new` needs a real terminal, so these build the struct
-    // directly against a capturing writer. That is the only way to get the
-    // render path itself under test rather than testing a reimplementation of
-    // it beside the code that ships.
+    // directly against a capturing writer.
 
     #[derive(Clone)]
     struct SharedBuf(Arc<Mutex<Vec<u8>>>);
@@ -1287,8 +1259,7 @@ mod screen_test {
         String::from_utf8(sink.lock().unwrap().clone()).unwrap()
     }
 
-    /// The default configuration must not take the row path at all — this is
-    /// the guard that the refactor left every existing user where they were.
+    /// The default configuration must not take the row path at all.
     #[test]
     fn single_row_input_keeps_the_horizontal_scroll_path() {
         let (mut screen, sink) = test_screen(20, 1);

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -141,6 +141,67 @@ pub fn wrap_line(line: &str, width: usize, padding: usize) -> Vec<&str> {
     lines
 }
 
+/// Hard-wrap a single line to `width` display columns, **losslessly**.
+///
+/// This is deliberately a second wrapper rather than an option on
+/// [`wrap_line`]. `wrap_line` is tuned for MUD *output* and is lossy by
+/// design: it breaks on word boundaries and drops the boundary space, and it
+/// discards a trailing segment that is entirely whitespace. That is right for
+/// prose and wrong for an input area, where the wrapped rows have to partition
+/// the buffer exactly — a dropped space shifts every character after it, so
+/// the cursor would render a column away from the text it edits.
+///
+/// The returned slices concatenate back to `line` byte for byte. Breaks only
+/// ever land on printable-character boundaries, so an escape sequence is never
+/// split; escapes are carried into whatever row they start in and consume no
+/// columns. A consequence, accepted rather than fixed: an SGR run that spans a
+/// break is not re-emitted on the continuation row, so styling stops there.
+///
+/// `line` must not contain `'\n'`. The vte parser behind
+/// `printable_char_indices` routes `'\n'` to `execute`, not `print`, so it is
+/// invisible here and two logical rows would silently be measured as one.
+/// Split on `'\n'` first, then call this on each segment.
+pub fn wrap_line_hard(line: &str, width: usize) -> Vec<&str> {
+    debug_assert!(
+        !line.contains('\n'),
+        "wrap_line_hard cannot see '\\n'; split on it first"
+    );
+
+    // A zero width would make every row empty and the loop never advance.
+    let width = width.max(1);
+    let mut rows: Vec<&str> = vec![];
+    let mut start = 0;
+
+    while start < line.len() {
+        let rest = &line[start..];
+        let (mut cut, _) = rest.byte_index_at_display_width(width);
+
+        if cut == 0 {
+            // The next glyph is wider than the whole row — a double-width
+            // character at `width == 1`, say. Nothing fits, but the row must
+            // still consume something or this loop spins forever. Overflow the
+            // row by one character, which is also what a terminal does.
+            cut = match rest.printable_char_indices().next() {
+                Some((idx, c)) => idx + c.len_utf8(),
+                // No printable characters at all (a bare escape sequence);
+                // take the remainder so the bytes are not lost.
+                None => rest.len(),
+            };
+        }
+
+        rows.push(&rest[..cut]);
+        start += cut;
+    }
+
+    // An empty input is one empty row, not zero rows — there is still a row
+    // the cursor sits on.
+    if rows.is_empty() {
+        rows.push(line);
+    }
+
+    rows
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,5 +303,91 @@ mod tests {
         // "abcdefghij" = 10 printable chars; at width 5 it must wrap.
         let lines = wrap_line(line, 5, 0);
         assert_eq!(lines.len(), 2);
+    }
+
+    /// The reason a second wrapper exists at all: `wrap_line` is lossy, and an
+    /// input area cannot be. Both properties are asserted side by side so the
+    /// justification cannot quietly stop being true.
+    #[test]
+    fn wrap_line_hard_preserves_all_characters() {
+        for line in [
+            "the quick brown fox jumps over the lazy dog",
+            "a b c d e f g h i j k l m n o p",
+            "trailing space kept   ",
+            "   leading space kept",
+            "no-spaces-at-all-in-this-very-long-token-here",
+            "",
+            " ",
+        ] {
+            for width in 1..=20usize {
+                let rows = wrap_line_hard(line, width);
+                assert_eq!(rows.concat(), line, "lossy at width {width} for {line:?}");
+            }
+        }
+
+        // And the contrast: where `wrap_line` takes its word-break path it
+        // drops the boundary space, so it fails the same round-trip. That is
+        // correct for MUD output, and is why it is left alone.
+        let line = "aaa bbb ccc";
+        assert_eq!(wrap_line(line, 6, 0), vec!["aaa", "bbb", "ccc"]);
+        assert_eq!(wrap_line(line, 6, 0).concat(), "aaabbbccc");
+        assert_eq!(wrap_line_hard(line, 6).concat(), line);
+    }
+
+    /// Every row must fit the terminal, except when a single glyph cannot.
+    #[test]
+    fn wrap_line_hard_rows_fit_the_width() {
+        let line = "hello 中文 world";
+        for width in 2..=20usize {
+            for row in wrap_line_hard(line, width) {
+                assert!(
+                    row.display_width() <= width,
+                    "row {row:?} exceeds width {width}"
+                );
+            }
+        }
+    }
+
+    /// A double-width glyph in a one-column terminal fits nowhere. The row has
+    /// to overflow rather than the wrap loop spinning forever.
+    #[test]
+    fn wrap_line_hard_terminates_on_glyph_wider_than_terminal() {
+        let rows = wrap_line_hard("中文", 1);
+        assert_eq!(rows, vec!["中", "文"]);
+        assert_eq!(rows.concat(), "中文");
+    }
+
+    /// Breaks land on printable-character boundaries, so an escape sequence is
+    /// never cut in half — a split escape would be printed as literal garbage.
+    #[test]
+    fn wrap_line_hard_never_splits_an_escape_sequence() {
+        let line = "\x1b[31mred\x1b[0m and \x1b[32mgreen\x1b[0m";
+        for width in 1..=20usize {
+            let rows = wrap_line_hard(line, width);
+            assert_eq!(rows.concat(), line);
+            for row in rows {
+                // A row holding a partial CSI would have an unterminated
+                // `\x1b[` with no final byte.
+                if let Some(esc) = row.rfind('\x1b') {
+                    assert!(
+                        row[esc..].chars().any(|c| c.is_ascii_alphabetic()),
+                        "row {row:?} ends mid-escape"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Escapes consume no columns, so they must not push text onto a new row.
+    #[test]
+    fn wrap_line_hard_escapes_do_not_consume_columns() {
+        let rows = wrap_line_hard("\x1b[31mabcde\x1b[0m", 5);
+        assert_eq!(rows.len(), 1);
+    }
+
+    /// Empty input is one row, not zero — the cursor still sits somewhere.
+    #[test]
+    fn wrap_line_hard_empty_input_is_one_row() {
+        assert_eq!(wrap_line_hard("", 10), vec![""]);
     }
 }

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -141,26 +141,23 @@ pub fn wrap_line(line: &str, width: usize, padding: usize) -> Vec<&str> {
     lines
 }
 
-/// Hard-wrap a single line to `width` display columns, **losslessly**.
+/// Hard-wrap a single line to `width` display columns, losslessly.
 ///
-/// This is deliberately a second wrapper rather than an option on
-/// [`wrap_line`]. `wrap_line` is tuned for MUD *output* and is lossy by
-/// design: it breaks on word boundaries and drops the boundary space, and it
-/// discards a trailing segment that is entirely whitespace. That is right for
-/// prose and wrong for an input area, where the wrapped rows have to partition
-/// the buffer exactly — a dropped space shifts every character after it, so
-/// the cursor would render a column away from the text it edits.
+/// This is a second wrapper rather than an option on [`wrap_line`], which is
+/// tuned for MUD output and lossy by design: it breaks on word boundaries and
+/// drops the boundary space, and discards a trailing whitespace-only segment.
+/// An input area needs the wrapped rows to partition the buffer exactly, or
+/// the cursor renders a column away from the text it edits.
 ///
 /// The returned slices concatenate back to `line` byte for byte. Breaks only
-/// ever land on printable-character boundaries, so an escape sequence is never
+/// land on printable-character boundaries, so an escape sequence is never
 /// split; escapes are carried into whatever row they start in and consume no
-/// columns. A consequence, accepted rather than fixed: an SGR run that spans a
-/// break is not re-emitted on the continuation row, so styling stops there.
+/// columns. An SGR run that spans a break is not re-emitted on the
+/// continuation row, so styling stops there.
 ///
-/// `line` must not contain `'\n'`. The vte parser behind
-/// `printable_char_indices` routes `'\n'` to `execute`, not `print`, so it is
-/// invisible here and two logical rows would silently be measured as one.
-/// Split on `'\n'` first, then call this on each segment.
+/// `line` must not contain `'\n'`: the vte parser behind
+/// `printable_char_indices` routes `'\n'` to `execute`, not `print`, so two
+/// logical rows would silently measure as one. Split on `'\n'` first.
 pub fn wrap_line_hard(line: &str, width: usize) -> Vec<&str> {
     debug_assert!(
         !line.contains('\n'),
@@ -305,9 +302,7 @@ mod tests {
         assert_eq!(lines.len(), 2);
     }
 
-    /// The reason a second wrapper exists at all: `wrap_line` is lossy, and an
-    /// input area cannot be. Both properties are asserted side by side so the
-    /// justification cannot quietly stop being true.
+    /// The rows must concatenate back to the input byte for byte.
     #[test]
     fn wrap_line_hard_preserves_all_characters() {
         for line in [
@@ -325,9 +320,8 @@ mod tests {
             }
         }
 
-        // And the contrast: where `wrap_line` takes its word-break path it
-        // drops the boundary space, so it fails the same round-trip. That is
-        // correct for MUD output, and is why it is left alone.
+        // `wrap_line` drops the word-break space, so it fails the same
+        // round-trip.
         let line = "aaa bbb ccc";
         assert_eq!(wrap_line(line, 6, 0), vec!["aaa", "bbb", "ccc"]);
         assert_eq!(wrap_line(line, 6, 0).concat(), "aaabbbccc");
@@ -348,8 +342,8 @@ mod tests {
         }
     }
 
-    /// A double-width glyph in a one-column terminal fits nowhere. The row has
-    /// to overflow rather than the wrap loop spinning forever.
+    /// A double-width glyph in a one-column terminal overflows its row rather
+    /// than spinning the wrap loop.
     #[test]
     fn wrap_line_hard_terminates_on_glyph_wider_than_terminal() {
         let rows = wrap_line_hard("中文", 1);


### PR DESCRIPTION
Behaviour-neutral refactor, extracted from work on a multi-line input area (#1472). Opening it separately because it stands on its own: it deletes duplicated arithmetic and fixes three reachable scroll-region defects.

> **First of two PRs — merge this one first.**
> #1480 implements the actual feature and is built directly on this branch. It cannot merge until this one does.
> If you'd rather not take the feature at all, this PR still stands on its own.

## Why

`SplitScreen::new` requires a real terminal, so none of the row/cursor arithmetic inside it can run in CI — the test module says so itself:

```rust
// Tests for print_line tag mask behaviour. SplitScreen::new requires a real
// terminal so we exercise the behaviour through History directly...
```

Layering wrap and cursor arithmetic onto that means shipping it untested, in the code path that produced #742. So the arithmetic moves into two pure modules and the renderer becomes a blitter.

## What's fixed

The layout math was duplicated and divergent between `new()` and `setup()` — `new()` hardcoded `output_start_line = 2` while `setup()` derived it. Both now call one `ScreenLayout::compute`. That surfaced three defects:

1. **`height - status_height - 2` underflowed** on short terminals. The near-miss matters more than the panic: saturating it would produce a DECSTBM region with `bottom <= top`, which terminals *discard entirely*, leaving the previous region in force — so every MUD line would scroll the whole screen and drag the status and input areas with it. That reads as "the UI is a bit glitchy" and survives casual testing far better than a crash. `compute` returns `Option` and refuses to render rather than emitting an invalid region.

2. **`init_scroll` emitted `ScrollRegion(scroll_range + 3, ...)`** while drawing its divider at `scroll_range + output_start_line`. The `3` is only correct while `output_start_line == 2`, which stops being true as soon as the tab indicator row appears — the divider then lands *inside* the scroll region and scrolls away on the next line of output.

3. **`scroll_range()` guarded on the terminal height**, which says nothing about how many rows the output region was actually left with after the top, status and input areas took their share, then subtracted `SCROLL_LIVE_BUFFER_SIZE` from it. With fewer than ten output rows this wrapped to ~65530 and was handed to DECSTBM.

Plus two coordinate-space defects, both the bug class that produced #742:

4. **`PromptMask::mask_buffer` advanced its offset by the mask's byte length** while splicing into a `Vec<char>`. ASCII masks hide it; any multi-byte mask from Lua displaced every subsequent index.

5. **`print_prompt_input` received `pos`** — documented one line above as "a character index" — and passed it to `byte_index_at_display_width`, which reads its argument as a *column* count. Those agree only while every character is one column wide, so a CJK glyph left of the cursor dragged it back one column per glyph. Separately, `SetPromptMask` paired the *masked* buffer with an *unmasked* cursor position. Masks are arbitrary Lua strings and printable masks are the documented use (`"this is *important*, ok"`), so `PromptMask::masked_index` now maps between the two spaces.

## What's new

- `src/ui/layout.rs` — vertical screen arithmetic as a pure function. 8 tests.
- `src/ui/input_layout.rs` — `rows`, `cursor_row_col`, `desired_height`, `visible_rows`. 21 tests. `cursor_row_col` is a *lookup into* `rows()`'s partition rather than a parallel reconstruction, because `byte_index_at_display_width` pushes a straddling wide character forward and leaves a hole — an independent calculation disagrees by a full row at every such hole.
- `wrap_line_hard` alongside an untouched `wrap_line`. `wrap_line` is lossy *by design* for MUD output — it drops the word-break space and discards a whitespace-only tail — which is right for prose and wrong for an input area, where the rows must partition the buffer exactly. `wrap_line_hard_preserves_all_characters` asserts both properties side by side so the justification can't quietly stop being true.
- 6 render tests against a capturing writer, which is what finally gets `print_prompt_input` under test without a TTY.

## Not behaviour-neutral

Three deliberate exceptions to the above:

- The `scroll_range` fix enables split-scroll on ~15–20-row terminals where the old height-based guard refused it. That's correct — there *is* room — but it's a change.
- The mask and character-index fixes change rendering for CJK input and for printable masks.
- The `cursor::Save`/`Restore` pair in `print_prompt_input` is gone. DECSC has one save slot per screen buffer, and saving there destroyed the position `setup()` deliberately stores at line 238; the restore was unobservable anyway because `goto_prompt()` overwrites the cursor on the very next byte.

## Testing

495 unit tests and all integration suites pass (`cargo test --locked`). `cargo fmt --check` is clean, and `cargo clippy --locked` produces a warning set identical to `dev` — no new warnings.

The new regression tests were checked by mutation: reverting the erase loop to a content-bounded clear fails `every_input_row_is_erased_even_when_content_shrinks`, and removing the scroll-window offset fails `content_taller_than_the_area_scrolls_within_it`.
