### PR TITLE
Add a multi-line input area

### DIFF
--- a/resources/help/bindings.md
+++ b/resources/help/bindings.md
@@ -57,6 +57,9 @@ The following options are available for `cmd`:
 - `"scroll_top"`        : Scroll output view to the top
 - `"scroll_bottom"`     : Scroll the output view to the bottom
 - `"complete"`          : Perform *tab-completion* on the current word
+- `"insert_newline"`    : Insert a row break in the input area
+- `"step_up"`           : Move the cursor to the previous row of the input area
+- `"step_down"`         : Move the cursor to the next row of the input area
 
 What follows is the default configuration that blightmud starts with. You can
 override this as you please using `blight.unbind` and `blight.bind`
@@ -100,9 +103,25 @@ blight.bind("ctrl-s", function()
     tts:stop()
 end)
 
--- History navigation
-blight.bind("up", history.previous_command)
-blight.bind("down", history.next_command)
+-- Insert a row in the input area
+set_newline_keys({ "ctrl-o", "alt-enter", "\x1b\r", "\x1b\n" })
+
+-- History navigation. Up/down move within the input area when there is
+-- somewhere to move to, and fall through to history at the edges.
+blight.bind("up", function()
+    if prompt.cursor_row() > 1 then
+        blight.ui("step_up")
+    else
+        history.previous_command()
+    end
+end)
+blight.bind("down", function()
+    if prompt.cursor_row() < prompt.row_count() then
+        blight.ui("step_down")
+    else
+        history.next_command()
+    end
+end)
 blight.bind("ctrl-p", history.previous_command)
 blight.bind("ctrl-n", history.next_command)
 
@@ -112,3 +131,60 @@ blight.bind("ctrl-t", function()
     blight.show_tags(not blight.show_tags())
 end)
 ```
+
+## Inserting a row in the input area
+
+`Enter` always submits. To compose a multi-row message you insert row breaks
+with a separate key, and several are bound by default:
+
+- `Ctrl-O` — works everywhere with no terminal configuration.
+- `Alt-Enter` — needs Meta enabled; see the macOS notes below.
+- The raw escape forms `\x1b\r` and `\x1b\n`, because some terminal and tmux
+  combinations deliver Option+Enter as unrecognised bytes rather than as an
+  Alt key, in which case the named binding never fires but this one does.
+
+`Ctrl-J` is *not* usable — terminals encode it identically to `Enter`.
+
+***set_newline_keys(keys)***
+Replaces the whole group in one call, so you do not have to know and unbind
+each default individually.
+
+```lua
+set_newline_keys({ "alt-enter" })             -- Alt/Option+Enter only
+set_newline_keys({ "ctrl-o" })                -- macOS-friendly, no Meta needed
+set_newline_keys({ "ctrl-o", "\x1b[13;2u" })   -- and a CSI-u Shift+Enter
+set_newline_keys({})                          -- disable row insertion entirely
+```
+
+## macOS keyboards
+
+Three things about macOS terminals are worth knowing, and they are why
+`Ctrl-O` rather than `Alt-Enter` is the primary binding:
+
+1. **Option is not Meta by default.** Terminal.app and iTerm2 both ship with
+   Option producing accented characters (`Option+a` gives `å`) rather than an
+   ESC prefix. Until you turn it on, Option+Enter sends nothing bindable — and
+   the same applies to the whole default `alt-*` group above.
+   - Terminal.app: Settings → Profiles → Keyboard → **Use Option as Meta key**
+   - iTerm2: Settings → Profiles → Keys → Left/Right Option key → **Esc+**
+2. **Command is invisible to terminals.** No terminal sends a Cmd chord to the
+   foreground process, so `blight.bind("cmd-enter", ...)` can never fire. To use
+   it, map Cmd+Enter to a custom escape sequence in your terminal and bind that.
+3. **Ctrl+Enter is indistinguishable from Enter**, and so is Shift+Enter: legacy
+   terminals encode all three as a carriage return. Only terminals implementing
+   the Kitty keyboard protocol / CSI-u can tell them apart.
+
+If you would rather not change any terminal settings, use `Ctrl-O` — it works
+as shipped in Terminal.app, iTerm2, Ghostty, WezTerm, Alacritty and kitty, and
+inside tmux and screen.
+
+To reach Shift+Enter or Cmd+Enter, configure your terminal to emit a CSI-u
+sequence for it and bind that sequence directly:
+
+```lua
+set_newline_keys({ "ctrl-o", "\x1b[13;2u" })  -- CSI-u Shift+Enter
+```
+
+Blightmud needs no special support for this: unrecognised escape sequences are
+echoed to the output when unbound, so you can press the key, read the bytes
+back, and bind exactly what your terminal sent.

--- a/resources/help/prompt.md
+++ b/resources/help/prompt.md
@@ -48,3 +48,53 @@ blight.add_prompt_listener(function (line)
 end)
 ```
 
+##
+
+***prompt.cursor_row() -> number***
+Gets the row the cursor is on within the input area, starting at 1.
+
+Rows here are the ones separated by newlines in the input buffer, not visual
+wrap rows. A buffer with no newlines is always one row.
+
+##
+
+***prompt.row_count() -> number***
+Gets the number of newline-separated rows in the input buffer, minimum 1.
+
+Together with `prompt.cursor_row()` this lets a binding decide whether there is
+somewhere to move before acting — which matters because `blight.ui` actions are
+applied *after* the binding returns, so a binding cannot observe whether a
+motion actually moved.
+
+```lua
+blight.bind("up", function()
+    if prompt.cursor_row() > 1 then
+        blight.ui("step_up")
+    else
+        history.previous_command()
+    end
+end)
+```
+
+##
+
+***blight.input_height([height]) -> int***
+Gets or sets the height, in rows, of the user input area. Defaults to `1`.
+
+- `height`  Optional. The requested minimum height, clamped to `1..=10`.
+- Returns the height the screen actually has.
+
+The returned value is what the screen *granted*, which is not always what was
+requested: a terminal too short to honour it gets fewer rows, and reader mode
+is always one row. NAWS reports this number to the MUD, so it has to be the
+truth rather than an echo.
+
+With `input_auto_expand` on, this is the *minimum* height and the area grows
+above it as the content requires, shrinking back when the content does. With it
+off — the default — this is a fixed height.
+
+This is not persisted. Set it from your config script:
+
+```lua
+blight.input_height(3)
+```

--- a/resources/help/prompt_mask.md
+++ b/resources/help/prompt_mask.md
@@ -50,3 +50,9 @@ Return the current prompt mask table (if any).
             previously set with calls to `prompt_mask.set`.
             Each index key will be a character index within the bounds
             of the current prompt input data (1-indexed).
+## Multi-row input
+
+A mask whose escape sequence spans a row break loses its styling on the
+continuation rows: each row is drawn independently and the active SGR state is
+not re-emitted. Masks are used for hiding passwords, which are single-row, so
+this is documented rather than fixed.

--- a/resources/help/settings.md
+++ b/resources/help/settings.md
@@ -90,3 +90,7 @@ After submitting a command it will be displayed in prompt with a background
 color. Typing anything will clear the "last command". Pressing `right`
 (stepping right) or `tab` will *activate* the command in the prompt and you can
 edit it.
+
+- `input_auto_expand` : Grow the input area as the text you are composing needs
+  more rows, and shrink it back. `blight.input_height()` sets the minimum.
+  Off by default.

--- a/resources/lua/bindings.lua
+++ b/resources/lua/bindings.lua
@@ -36,9 +36,41 @@ blight.bind("ctrl-s", function()
     tts:stop()
 end)
 
+-- Insert a row in the input area.
+--
+-- ctrl-o is the primary binding because it needs no terminal configuration
+-- anywhere, macOS included. alt-enter only works once "Option as Meta" is
+-- enabled, which Terminal.app and iTerm2 both ship with *off*, and some
+-- braille and keyboard-emulation stacks never deliver it at all. ctrl-j is
+-- not usable: it is byte-identical to Enter.
+--
+-- The raw escape forms are bound too because some terminal/tmux combinations
+-- deliver Option+Enter as unrecognised bytes rather than as an Alt key, in
+-- which case the named binding never fires but this one does.
+--
+-- Retarget the whole group in one call with set_newline_keys{...}.
+set_newline_keys({ "ctrl-o", "alt-enter", "\x1b\r", "\x1b\n" })
+
 -- History navigation
-blight.bind("up", history.previous_command)
-blight.bind("down", history.next_command)
+--
+-- Up and Down move within the input area when there is somewhere to move to,
+-- and fall through to command history at the edges. With no row breaks in the
+-- buffer this is exactly the previous behaviour. ctrl-p and ctrl-n stay bound
+-- to history unconditionally as the always-available escape hatch.
+blight.bind("up", function()
+    if prompt.cursor_row() > 1 then
+        blight.ui("step_up")
+    else
+        history.previous_command()
+    end
+end)
+blight.bind("down", function()
+    if prompt.cursor_row() < prompt.row_count() then
+        blight.ui("step_down")
+    else
+        history.next_command()
+    end
+end)
 blight.bind("ctrl-p", history.previous_command)
 blight.bind("ctrl-n", history.next_command)
 

--- a/resources/lua/functions.lua
+++ b/resources/lua/functions.lua
@@ -28,3 +28,46 @@ function cformat(msg, ...)
 
     return msg:format(...)
 end
+
+-- Keys currently bound to insert_newline, so a later call can unbind them.
+local newline_keys = {}
+
+-- Reproduce the normalisation blight.bind applies, so that unbind removes what
+-- bind stored. bind lowercases the key *except* in the alt- branch, where it
+-- lowercases only the prefix so that alt-H and alt-h stay distinct; unbind
+-- does no normalisation at all and sets the raw string to nil.
+local function normalize_bind_key(key)
+    if key:lower():sub(1, 4) == "alt-" then
+        return "alt" .. key:sub(4)
+    end
+    return key:lower()
+end
+
+--- Retarget the keys that insert a row in the input area.
+---
+--- Replaces the whole group, so a user does not have to know and unbind each
+--- default individually:
+---
+---   set_newline_keys({ "alt-enter" })            -- Alt/Option+Enter only
+---   set_newline_keys({ "ctrl-o" })               -- macOS, no Meta needed
+---   set_newline_keys({ "ctrl-o", "\x1b[13;2u" })  -- and a CSI-u Shift+Enter
+---   set_newline_keys({})                         -- disable row insertion
+---
+--- Enter always submits and is not affected.
+---@param keys string[]
+function set_newline_keys(keys)
+    for _, key in ipairs(newline_keys) do
+        -- blight.bind lowercases the key except in the alt- branch, while
+        -- blight.unbind does no normalisation at all, so unbinding has to use
+        -- exactly the string bind would have stored.
+        blight.unbind(normalize_bind_key(key))
+    end
+
+    newline_keys = {}
+    for _, key in ipairs(keys) do
+        blight.bind(key, function()
+            blight.ui("insert_newline")
+        end)
+        table.insert(newline_keys, key)
+    end
+end

--- a/resources/lua/naws.lua
+++ b/resources/lua/naws.lua
@@ -15,10 +15,11 @@ local function network_dimensions(width, height)
 end
 
 local function send_dimensions(width, height)
-    -- We must adjust the height to just the writable area, subtracting
-    -- the size by 2 for the input/prompt area, and by the size of the status
-    -- area.
-    height = height - 2 - blight.status_height()
+    -- Adjust the height to just the writable area: one row for the MUD's
+    -- own prompt, however many rows the input area occupies, and the size of
+    -- the status area. The input area used to be assumed to be one row, which
+    -- is why this was a literal 2.
+    height = height - 1 - blight.input_height() - blight.status_height()
     core.subneg_send(NAWS_PROTOCOL, network_dimensions(width, height))
 end
 

--- a/resources/lua/types/blightmud.d.lua
+++ b/resources/lua/types/blightmud.d.lua
@@ -242,14 +242,15 @@ function BlightLib.unbind(key) end
 ---Sends a UI command string.
 ---
 ---Navigation: `"step_left"`, `"step_right"`, `"step_to_start"`, `"step_to_end"`,
----`"step_word_left"`, `"step_word_right"`
+---`"step_word_left"`, `"step_word_right"`, `"step_up"`, `"step_down"`
 ---
 ---Deletion: `"delete"`, `"delete_right"`, `"delete_word_left"`, `"delete_word_right"`,
 ---`"delete_to_end"`, `"delete_from_start"`
 ---
 ---Scrolling: `"scroll_up"`, `"scroll_down"`, `"scroll_top"`, `"scroll_bottom"`
 ---
----Other: `"complete"` (tab-completion)
+---Other: `"complete"` (tab-completion), `"insert_newline"` (insert a row
+---break in the input area)
 ---@param cmd string
 function BlightLib.ui(cmd) end
 
@@ -269,6 +270,16 @@ function BlightLib.is_reader_mode() end
 ---@param height? integer  Clamped to 0–5.
 ---@return integer
 function BlightLib.status_height(height) end
+
+---Gets or sets the height, in rows, of the user input area.
+---
+---Returns the height the screen actually has, which is not always what was
+---requested: a terminal too short to honour it gets fewer rows, and reader
+---mode is always 1. With the `input_auto_expand` setting on this is a minimum
+---rather than a fixed height.
+---@param height? integer  Clamped to 1-10.
+---@return integer
+function BlightLib.input_height(height) end
 
 ---Sets the content of a status bar line.
 ---Index is 0-based; out-of-range values default to the last/first line.
@@ -695,6 +706,15 @@ function PromptLib.get_cursor_pos() end
 ---Sets the cursor position in the prompt (1-based).
 ---@param pos integer
 function PromptLib.set_cursor_pos(pos) end
+
+---Returns the row the cursor is on within the input area (1-based).
+---Rows are separated by newlines in the buffer, not by visual wrapping.
+---@return integer
+function PromptLib.cursor_row() end
+
+---Returns the number of newline-separated rows in the input buffer (minimum 1).
+---@return integer
+function PromptLib.row_count() end
 
 ---Registers a callback invoked on every prompt input change.
 ---@param callback fun()
@@ -1689,3 +1709,10 @@ BG_BMAGENTA = "\x1b[105m"
 BG_BCYAN = "\x1b[106m"
 ---@type string
 BG_BWHITE = "\x1b[107m"
+
+---Replaces the set of keys bound to inserting a row break in the input area.
+---
+---`Enter` always submits and is unaffected. Pass an empty table to disable row
+---insertion entirely.
+---@param keys string[]
+function set_newline_keys(keys) end

--- a/src/event.rs
+++ b/src/event.rs
@@ -114,6 +114,7 @@ pub enum Event {
     SpeakStop,
     StartLogging(String, bool),
     StatusAreaHeight(u16),
+    InputHeight(u16),
     StatusLine(usize, String),
     StopLogging,
     StopMusic,

--- a/src/event.rs
+++ b/src/event.rs
@@ -463,7 +463,10 @@ impl EventHandler {
                     lua_ctx.set_prompt_mask_content(updated_mask_table);
                     let mut prompt_input = self.session.prompt_input.lock().unwrap();
                     *prompt_input = command_buffer.get_masked_buffer();
-                    screen.print_prompt_input(&prompt_input, command_buffer.get_pos());
+                    // Masked string, masked cursor. `get_pos` indexes the raw
+                    // buffer and would point into the wrong place as soon as a
+                    // mask inserts anything before the cursor.
+                    screen.print_prompt_input(&prompt_input, command_buffer.get_masked_pos());
                 }
                 Ok(())
             }
@@ -475,7 +478,10 @@ impl EventHandler {
                     }
                     let mut prompt_input = self.session.prompt_input.lock().unwrap();
                     *prompt_input = command_buffer.get_masked_buffer();
-                    screen.print_prompt_input(&prompt_input, command_buffer.get_pos());
+                    // The mask was just cleared, so this is the identity — but
+                    // it is spelled the same way as the branch above so the
+                    // pairing stays obviously correct.
+                    screen.print_prompt_input(&prompt_input, command_buffer.get_masked_pos());
                 }
                 Ok(())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ mod ui;
 use crate::event::{spawn_quit_confirm_timeout_thread, Event, QuitMethod};
 use crate::io::{FSMonitor, SaveData};
 use crate::model::{
-    Servers, ECHO_INPUT, HIDE_TOPBAR, LAST_COMMAND, LOG_TIMESTAMPS, READER_MODE, SCROLL_SPLIT,
-    TAB_INDICATOR_BRAND, TAB_INDICATOR_INLINE, TAB_INDICATOR_VISIBLE,
+    Servers, ECHO_INPUT, HIDE_TOPBAR, INPUT_AUTO_EXPAND, LAST_COMMAND, LOG_TIMESTAMPS, READER_MODE,
+    SCROLL_SPLIT, TAB_INDICATOR_BRAND, TAB_INDICATOR_INLINE, TAB_INDICATOR_VISIBLE,
 };
 use crate::session::{Session, SessionBuilder};
 use crate::timer::{spawn_timer_thread, TimerEvent};
@@ -417,13 +417,22 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
                     if let Ok(mut lua) = session.lua_script.lock() {
                         lua.set_reader_mode(value);
                     }
+                    // The screen is replaced wholesale here, so a configured
+                    // input height has to be carried across or it is silently
+                    // lost on every reader-mode toggle.
+                    let input_height = screen.input_height();
                     screen = Box::new(UiWrapper::new_from(screen, &session, value)?);
+                    screen.set_input_height(input_height)?;
+                    if let Ok(mut lua) = session.lua_script.lock() {
+                        lua.set_input_height(screen.input_height());
+                    }
                 }
                 HIDE_TOPBAR
                 | SCROLL_SPLIT
                 | TAB_INDICATOR_VISIBLE
                 | TAB_INDICATOR_BRAND
-                | TAB_INDICATOR_INLINE => {
+                | TAB_INDICATOR_INLINE
+                | INPUT_AUTO_EXPAND => {
                     screen.setup()?;
                 }
                 ECHO_INPUT => session.echo_input.store(value, Ordering::Relaxed),
@@ -510,7 +519,23 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
             | Event::FindBackward(_) => {
                 event_handler.handle_scroll_events(event, &mut screen)?;
             }
-            Event::StatusAreaHeight(height) => screen.set_status_area_height(height)?,
+            Event::StatusAreaHeight(height) => {
+                screen.set_status_area_height(height)?;
+                if let Ok(mut script) = session.lua_script.lock() {
+                    // Resizing a region changes the writable area the MUD is
+                    // told about, but the dimension listeners only fired on
+                    // Redraw, so NAWS never re-reported. Pre-existing for the
+                    // status area; fixed here for both.
+                    script.set_dimensions((screen.width(), screen.height()));
+                }
+            }
+            Event::InputHeight(height) => {
+                screen.set_input_height(height)?;
+                if let Ok(mut script) = session.lua_script.lock() {
+                    script.set_input_height(screen.input_height());
+                    script.set_dimensions((screen.width(), screen.height()));
+                }
+            }
             Event::ShowTags(show) => screen.set_show_tags(show)?,
             Event::SetTagMask(mask) => screen.set_tag_mask(mask),
             Event::SetHistoryCapacity(capacity) => screen.set_history_capacity(capacity),
@@ -620,7 +645,11 @@ For more info: https://github.com/LiquidityC/Blightmud/issues/173"#;
                     script.set_dimensions((screen.width(), screen.height()));
                 }
                 let prompt_input = session.prompt_input.lock().unwrap();
-                screen.print_prompt_input(&prompt_input, prompt_input.len());
+                // A character index, not a byte length: `.len()` put the
+                // cursor past the end of any non-ASCII buffer, which a
+                // wrapped multi-row input would render as a wrong row.
+                let pos = prompt_input.chars().count();
+                screen.print_prompt_input(&prompt_input, pos);
             }
             Event::Quit(method) => {
                 if Settings::load().get(CONFIRM_QUIT)?

--- a/src/lua/blight.rs
+++ b/src/lua/blight.rs
@@ -2,7 +2,10 @@ use super::{constants::*, regex::Regex, ui_event::UiEvent};
 use crate::event::{Event, QuitMethod, TabCommand};
 use crate::io::SaveData;
 use crate::tabs::{TabOpts, TabSet};
-use crate::ui::{TopPrefix, TopPrefixStyle, TopRowBody, TopRowOpts, TopRowSelector};
+use crate::ui::{
+    TopPrefix, TopPrefixStyle, TopRowBody, TopRowOpts, TopRowSelector, INPUT_HEIGHT_MAX,
+    INPUT_HEIGHT_MIN,
+};
 use crate::{
     model::{self, Line, TagMask},
     tools::printable_chars::PrintableCharsIterator,
@@ -245,6 +248,19 @@ impl UserData for Blight {
                 height
             } else {
                 ctx.named_registry_value(STATUS_AREA_HEIGHT)?
+            };
+            Ok(height)
+        });
+        methods.add_function("input_height", |ctx, requested: Option<u16>| {
+            let height: u16 = if let Some(height) = requested {
+                let height = height.clamp(INPUT_HEIGHT_MIN, INPUT_HEIGHT_MAX);
+                let this_aux = ctx.globals().get::<AnyUserData>("blight")?;
+                let this = this_aux.borrow::<Blight>()?;
+                this.main_writer.send(Event::InputHeight(height)).unwrap();
+                ctx.set_named_registry_value(INPUT_HEIGHT, height)?;
+                height
+            } else {
+                ctx.named_registry_value(INPUT_HEIGHT)?
             };
             Ok(height)
         });
@@ -655,7 +671,8 @@ mod test_blight {
     use super::Blight;
     use crate::lua::constants::{
         BLIGHT_ON_DIMENSIONS_CHANGE_LISTENER_TABLE, BLIGHT_ON_QUIT_LISTENER_TABLE,
-        COMMAND_BINDING_TABLE, COMPLETION_CALLBACK_TABLE, SHOW_TAGS, STATUS_AREA_HEIGHT,
+        COMMAND_BINDING_TABLE, COMPLETION_CALLBACK_TABLE, INPUT_HEIGHT, SHOW_TAGS,
+        STATUS_AREA_HEIGHT,
     };
     use crate::{PROJECT_NAME, VERSION};
 
@@ -677,6 +694,7 @@ mod test_blight {
             .unwrap();
         lua.set_named_registry_value(COMMAND_BINDING_TABLE, lua.create_table().unwrap())
             .unwrap();
+        lua.set_named_registry_value(INPUT_HEIGHT, 1u16).unwrap();
         lua.set_named_registry_value(STATUS_AREA_HEIGHT, 1u16)
             .unwrap();
         lua.set_named_registry_value(SHOW_TAGS, false).unwrap();
@@ -919,6 +937,21 @@ mod test_blight {
             .call::<bool>(())
             .unwrap();
         assert!(!val);
+    }
+
+    #[test]
+    fn test_input_height() {
+        let (lua, _reader) = get_lua_state();
+        let get = |lua: &Lua, src: &str| lua.load(src).call::<u16>(()).unwrap();
+
+        assert_eq!(get(&lua, "return blight.input_height()"), 1);
+        assert_eq!(get(&lua, "return blight.input_height(3)"), 3);
+        assert_eq!(get(&lua, "return blight.input_height()"), 3);
+
+        // Clamped at both ends: zero would leave nowhere to type, and the
+        // upper bound keeps the output region renderable.
+        assert_eq!(get(&lua, "return blight.input_height(0)"), 1);
+        assert_eq!(get(&lua, "return blight.input_height(500)"), 10);
     }
 
     #[test]

--- a/src/lua/constants.rs
+++ b/src/lua/constants.rs
@@ -22,6 +22,7 @@ pub const PROMPT_INPUT_LISTENER_TABLE: &str = "__prompt_listeners";
 pub const FS_LISTENERS: &str = "__fs_listeners";
 pub const SCRIPT_RESET_LISTENERS: &str = "__script_reset_listeners";
 pub const STATUS_AREA_HEIGHT: &str = "__status_area_height";
+pub const INPUT_HEIGHT: &str = "__input_height";
 pub const SHOW_TAGS: &str = "__show_tags";
 
 // Core tables

--- a/src/lua/lua_script.rs
+++ b/src/lua/lua_script.rs
@@ -193,6 +193,7 @@ fn create_default_lua_state(builder: LuaScriptBuilder, store: Option<Store>) -> 
         state.set_named_registry_value(PROMPT_CURSOR_INDEX, 0)?;
         state.set_named_registry_value(PROMPT_INPUT_LISTENER_TABLE, state.create_table()?)?;
         state.set_named_registry_value(STATUS_AREA_HEIGHT, 1)?;
+        state.set_named_registry_value(INPUT_HEIGHT, 1)?;
 
         globals.set("blight", blight)?;
         globals.set("core", Core::new(writer.clone()))?;
@@ -541,6 +542,20 @@ impl LuaScript {
                 let (_, cb) = pair?;
                 cb.call::<()>(dim)?;
             }
+            Ok(())
+        });
+    }
+
+    /// Publish the input area height the screen actually granted.
+    ///
+    /// This is deliberately written from the screen rather than from
+    /// `blight.input_height(n)`, because the two differ: the layout clamps the
+    /// request on a short terminal, and reader mode ignores it entirely. NAWS
+    /// reports this number to the MUD, so an echo of the request would give
+    /// the server a wrong window height.
+    pub fn set_input_height(&mut self, height: u16) {
+        self.exec_lua(&mut || -> LuaResult<()> {
+            self.state.set_named_registry_value(INPUT_HEIGHT, height)?;
             Ok(())
         });
     }

--- a/src/lua/prompt.rs
+++ b/src/lua/prompt.rs
@@ -32,6 +32,22 @@ impl UserData for Prompt {
                 result
             }
         });
+        // Both of these are 1-based, matching `get_cursor_pos` above and Lua
+        // convention generally: the first row is row 1.
+        //
+        // They exist rather than having Lua scan `prompt.get()` itself because
+        // `get_cursor_pos` is a *character* index while Lua's `string.sub` is
+        // *byte*-based — a scan would split at the wrong point on any
+        // non-ASCII input.
+        methods.add_function("cursor_row", |ctx, ()| -> mlua::Result<usize> {
+            let content: String = ctx.named_registry_value(PROMPT_CONTENT)?;
+            let pos: usize = ctx.named_registry_value(PROMPT_CURSOR_INDEX)?;
+            Ok(content.chars().take(pos).filter(|c| *c == '\n').count() + 1)
+        });
+        methods.add_function("row_count", |ctx, ()| -> mlua::Result<usize> {
+            let content: String = ctx.named_registry_value(PROMPT_CONTENT)?;
+            Ok(content.chars().filter(|c| *c == '\n').count() + 1)
+        });
         methods.add_function("set_cursor_pos", |ctx, pos: usize| {
             let pos = if pos > 0 { pos - 1 } else { pos };
             let backend: Backend = ctx.named_registry_value(BACKEND)?;
@@ -162,5 +178,96 @@ mod test_prompt {
             .named_registry_value(PROMPT_INPUT_LISTENER_TABLE)
             .unwrap();
         assert_eq!(table.raw_len(), 3);
+    }
+
+    #[test]
+    fn test_prompt_rows_are_one_based() {
+        let (lua, _reader) = setup_lua();
+        lua.set_named_registry_value(PROMPT_CONTENT, "one\ntwo\nthree".to_string())
+            .unwrap();
+
+        // Cursor on the first row.
+        lua.set_named_registry_value(PROMPT_CURSOR_INDEX, 0usize)
+            .unwrap();
+        assert_eq!(
+            lua.load("return prompt.cursor_row()")
+                .call::<usize>(())
+                .unwrap(),
+            1
+        );
+
+        // Just before the first newline is still row 1; just after is row 2.
+        lua.set_named_registry_value(PROMPT_CURSOR_INDEX, 3usize)
+            .unwrap();
+        assert_eq!(
+            lua.load("return prompt.cursor_row()")
+                .call::<usize>(())
+                .unwrap(),
+            1
+        );
+        lua.set_named_registry_value(PROMPT_CURSOR_INDEX, 4usize)
+            .unwrap();
+        assert_eq!(
+            lua.load("return prompt.cursor_row()")
+                .call::<usize>(())
+                .unwrap(),
+            2
+        );
+
+        assert_eq!(
+            lua.load("return prompt.row_count()")
+                .call::<usize>(())
+                .unwrap(),
+            3
+        );
+    }
+
+    /// The common case: no row breaks means one row, so the up/down bindings
+    /// fall straight through to history exactly as they did before.
+    #[test]
+    fn test_prompt_rows_without_newlines() {
+        let (lua, _reader) = setup_lua();
+        lua.set_named_registry_value(PROMPT_CONTENT, "plain".to_string())
+            .unwrap();
+        lua.set_named_registry_value(PROMPT_CURSOR_INDEX, 3usize)
+            .unwrap();
+        assert_eq!(
+            lua.load("return prompt.cursor_row()")
+                .call::<usize>(())
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            lua.load("return prompt.row_count()")
+                .call::<usize>(())
+                .unwrap(),
+            1
+        );
+    }
+
+    /// cursor_row counts characters, not bytes — a byte-based scan in Lua
+    /// would split multi-byte input at the wrong point.
+    #[test]
+    fn test_prompt_cursor_row_counts_characters() {
+        let (lua, _reader) = setup_lua();
+        lua.set_named_registry_value(PROMPT_CONTENT, "\u{4e2d}\u{6587}\nx".to_string())
+            .unwrap();
+        // Two CJK characters then the newline: char index 2 is still row 1.
+        lua.set_named_registry_value(PROMPT_CURSOR_INDEX, 2usize)
+            .unwrap();
+        assert_eq!(
+            lua.load("return prompt.cursor_row()")
+                .call::<usize>(())
+                .unwrap(),
+            1
+        );
+        lua.set_named_registry_value(PROMPT_CURSOR_INDEX, 3usize)
+            .unwrap();
+        assert_eq!(
+            lua.load("return prompt.cursor_row()")
+                .call::<usize>(())
+                .unwrap(),
+            2
+        );
     }
 }

--- a/src/lua/ui_event.rs
+++ b/src/lua/ui_event.rs
@@ -17,6 +17,9 @@ pub enum UiEvent {
     ScrollTop,
     ScrollBottom,
     Complete,
+    InsertNewline,
+    StepUp,
+    StepDown,
     Unknown(String),
 }
 
@@ -40,6 +43,9 @@ impl From<&str> for UiEvent {
             "scroll_top" => UiEvent::ScrollTop,
             "scroll_bottom" => UiEvent::ScrollBottom,
             "complete" => UiEvent::Complete,
+            "insert_newline" => UiEvent::InsertNewline,
+            "step_up" => UiEvent::StepUp,
+            "step_down" => UiEvent::StepDown,
             _ => UiEvent::Unknown(s.to_string()),
         }
     }

--- a/src/model/prompt_mask.rs
+++ b/src/model/prompt_mask.rs
@@ -27,10 +27,45 @@ impl PromptMask {
                 return masked_buf.iter().collect();
             }
             masked_buf.splice(adjusted_idx..adjusted_idx, mask.chars());
-            offset += mask.len();
+            // `masked_buf` is a `Vec<char>`, so the splice grew it by the
+            // mask's *character* count. `mask.len()` is its byte length, which
+            // only agrees for ASCII masks — any multi-byte mask coming from
+            // Lua pushed every subsequent index too far right.
+            offset += mask.chars().count();
         }
 
         masked_buf.iter().collect()
+    }
+
+    /// Map a character index in the unmasked buffer to the equivalent index in
+    /// the string [`Self::mask_buffer`] produces.
+    ///
+    /// Without this the cursor and the text it points at come from different
+    /// coordinate spaces. A mask is not required to be an escape sequence —
+    /// Lua may supply any string, and printable masks are the documented use
+    /// (`"this is *important*, ok"`) — so the shift is real, not notional.
+    ///
+    /// `buf_len` is the unmasked buffer's character count, and exists so this
+    /// reproduces `mask_buffer`'s behaviour exactly: an out-of-range index
+    /// makes it stop applying masks altogether, so this must stop shifting at
+    /// the same point or the two disagree.
+    pub fn masked_index(&self, unmasked_idx: usize, buf_len: usize) -> usize {
+        let mut offset = 0usize;
+        for (idx, mask) in self.iter() {
+            // The same cast `mask_buffer` performs, wrap included: a negative
+            // index becomes enormous and trips the bounds check there too.
+            let idx = *idx as usize;
+            if idx > buf_len {
+                break;
+            }
+            if idx > unmasked_idx {
+                break;
+            }
+            // A mask anchored exactly at the cursor is spliced in *before* it,
+            // so it pushes the cursor right.
+            offset += mask.chars().count();
+        }
+        unmasked_idx + offset
     }
 
     pub fn to_table<'a>(&'a self, ctx: &'a Lua) -> LuaResult<LuaTable> {
@@ -152,5 +187,129 @@ mod test_prompt_mask {
         ]));
         let res = invalid_mask.mask_buffer(&buf);
         assert_eq!(res, "this is *important, ok");
+    }
+
+    /// `offset` used to advance by the mask's byte length while the buffer it
+    /// indexes is a `Vec<char>`. A multi-byte mask therefore over-advanced,
+    /// and every mask after the first landed too far right.
+    #[test]
+    fn mask_with_multibyte_content_keeps_subsequent_indices_aligned() {
+        let buf: Vec<char> = "this is important, ok".chars().collect();
+
+        // "»" is one char but two bytes; "«" likewise.
+        let mask = PromptMask::from(BTreeMap::from([
+            (8, "»".to_string()),
+            (17, "«".to_string()),
+        ]));
+
+        assert_eq!(mask.mask_buffer(&buf), "this is »important«, ok");
+    }
+
+    /// A mask anchored exactly at the end of the buffer is in bounds and must
+    /// be appended, not dropped.
+    #[test]
+    fn mask_at_exact_buffer_end_is_appended() {
+        let buf: Vec<char> = "abc".chars().collect();
+        let mask = PromptMask::from(BTreeMap::from([(3, "!".to_string())]));
+        assert_eq!(mask.mask_buffer(&buf), "abc!");
+    }
+
+    /// The cursor index must be translated into the same coordinate space as
+    /// the string it indexes. Asserted against `mask_buffer` rather than
+    /// hand-written numbers, so the two cannot drift.
+    #[test]
+    fn masked_index_agrees_with_mask_buffer() {
+        let buf: Vec<char> = "this is important, ok".chars().collect();
+
+        for mask in [
+            // Printable masks, which shift real columns.
+            PromptMask::from(BTreeMap::from([
+                (8, "*".to_string()),
+                (17, "*".to_string()),
+            ])),
+            // Escape masks, which shift indices but no columns.
+            PromptMask::from(BTreeMap::from([
+                (0, "\x1b[44m".to_string()),
+                (21, "\x1b[0m".to_string()),
+            ])),
+            // Multi-byte, multi-char masks.
+            PromptMask::from(BTreeMap::from([(4, "»«".to_string())])),
+            PromptMask::new(),
+        ] {
+            let masked: Vec<char> = mask.mask_buffer(&buf).chars().collect();
+
+            for pos in 0..=buf.len() {
+                let mapped = mask.masked_index(pos, buf.len());
+                assert!(
+                    mapped <= masked.len(),
+                    "index {mapped} out of range for {masked:?}"
+                );
+                // The cursor must sit immediately before the same character it
+                // sat before in the unmasked buffer. A mask anchored exactly
+                // at the cursor belongs to its left — which is what makes the
+                // boundary `<=` rather than `<`.
+                if pos < buf.len() {
+                    assert_eq!(
+                        masked[mapped],
+                        buf[pos],
+                        "cursor {pos} -> {mapped} points at the wrong character \
+                         in {:?}",
+                        masked.iter().collect::<String>()
+                    );
+                }
+            }
+
+            // The end of the buffer maps to the end of the masked buffer.
+            assert_eq!(mask.masked_index(buf.len(), buf.len()), masked.len());
+        }
+    }
+
+    /// With no mask the mapping is the identity, which is what keeps the
+    /// ordinary no-mask render path unchanged.
+    #[test]
+    fn masked_index_is_identity_without_a_mask() {
+        let mask = PromptMask::new();
+        for pos in 0..10 {
+            assert_eq!(mask.masked_index(pos, 9), pos);
+        }
+    }
+
+    /// `mask_buffer` stops applying masks at the first out-of-range index, so
+    /// the index map must stop shifting at exactly the same point.
+    #[test]
+    fn masked_index_stops_where_mask_buffer_stops() {
+        let buf: Vec<char> = "abc".chars().collect();
+        let mask = PromptMask::from(BTreeMap::from([
+            (1, "*".to_string()),
+            (99, "!".to_string()),
+            (2, "#".to_string()),
+        ]));
+
+        let masked: Vec<char> = mask.mask_buffer(&buf).chars().collect();
+        assert_eq!(masked.iter().collect::<String>(), "a*b#c");
+
+        for pos in 0..buf.len() {
+            let mapped = mask.masked_index(pos, buf.len());
+            assert_eq!(masked[mapped], buf[pos], "cursor {pos} -> {mapped}");
+        }
+        assert_eq!(mask.masked_index(buf.len(), buf.len()), masked.len());
+    }
+
+    /// Regression pin for PR #742: an out-of-range index must not panic. Note
+    /// the behaviour it pins is that the remaining masks are *silently
+    /// dropped* — the bounds check returns early rather than skipping the one
+    /// bad entry.
+    #[test]
+    fn mask_past_end_drops_remainder_without_panicking() {
+        let buf: Vec<char> = "abc".chars().collect();
+        let mask = PromptMask::from(BTreeMap::from([
+            (1, "*".to_string()),
+            (99, "!".to_string()),
+            (2, "#".to_string()),
+        ]));
+
+        // BTreeMap iterates in key order, so 1 and 2 are applied and the
+        // out-of-range 99 ends the loop with nothing further applied.
+        assert_eq!(mask.mask_buffer(&buf), "a*b#c");
     }
 }

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -29,8 +29,12 @@ pub const LOG_TIMESTAMPS: &str = "log_timestamps";
 pub const TAB_INDICATOR_VISIBLE: &str = "tab_indicator_visible";
 pub const TAB_INDICATOR_BRAND: &str = "tab_indicator_brand";
 pub const TAB_INDICATOR_INLINE: &str = "tab_indicator_inline";
+/// Grow the input area past `blight.input_height()` as the content needs
+/// it, and shrink it back. Off by default, so the default render path is
+/// unchanged.
+pub const INPUT_AUTO_EXPAND: &str = "input_auto_expand";
 
-pub const SETTINGS: [&str; 18] = [
+pub const SETTINGS: [&str; 19] = [
     LOGGING_ENABLED,
     TTS_ENABLED,
     MOUSE_ENABLED,
@@ -49,6 +53,7 @@ pub const SETTINGS: [&str; 18] = [
     TAB_INDICATOR_VISIBLE,
     TAB_INDICATOR_BRAND,
     TAB_INDICATOR_INLINE,
+    INPUT_AUTO_EXPAND,
 ];
 
 impl Settings {
@@ -91,6 +96,7 @@ impl Default for Settings {
         settings.insert(TAB_INDICATOR_VISIBLE.to_string(), true);
         settings.insert(TAB_INDICATOR_BRAND.to_string(), true);
         settings.insert(TAB_INDICATOR_INLINE.to_string(), false);
+        settings.insert(INPUT_AUTO_EXPAND.to_string(), false);
         Self { settings }
     }
 }

--- a/src/tts/text_to_speech.rs
+++ b/src/tts/text_to_speech.rs
@@ -149,9 +149,19 @@ impl TTSController {
         }
     }
 
-    pub fn speak_input(&self, line: &str) {
+    /// Announce a line the user submitted.
+    ///
+    /// `interrupt` exists because a multi-row submit sends one line per row in
+    /// a tight loop. `flush()` is `queue.flush(); tts.stop()`, so flushing on
+    /// every row would enqueue and immediately cancel all but the last — a
+    /// blind user would hear only the final row of what they sent, which
+    /// inverts the compose area's whole benefit into a correctness hazard.
+    /// Only the first row of a batch interrupts; the rest queue behind it.
+    pub fn speak_input(&self, line: &str, interrupt: bool) {
         if self.enabled {
-            self.flush();
+            if interrupt {
+                self.flush();
+            }
             let input = line.trim();
             let speak = if !input.is_empty() {
                 format!("input: {input}")

--- a/src/ui/command.rs
+++ b/src/ui/command.rs
@@ -129,7 +129,14 @@ impl CommandBuffer {
         // Insert history
         let cmd = if !self.buffer.is_empty() {
             let command = self.get_buffer();
-            self.completion_tree.insert(&command);
+            // Each row is submitted as its own command, so completion has to
+            // offer them separately — a candidate containing a newline could
+            // never be typed back in.
+            for row in command.split('\n') {
+                if !row.trim().is_empty() {
+                    self.completion_tree.insert(row);
+                }
+            }
             command
         } else {
             String::new()
@@ -153,6 +160,53 @@ impl CommandBuffer {
         if self.cursor_pos > 0 {
             self.cursor_pos -= 1;
         }
+    }
+
+    /// Start index and length of the `'\n'`-delimited row containing `pos`.
+    fn logical_row_at(&self, pos: usize) -> (usize, usize) {
+        let start = self.buffer[..pos]
+            .iter()
+            .rposition(|c| *c == '\n')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let end = self.buffer[pos..]
+            .iter()
+            .position(|c| *c == '\n')
+            .map(|i| pos + i)
+            .unwrap_or(self.buffer.len());
+        (start, end - start)
+    }
+
+    /// Move to the same column on the previous logical row.
+    ///
+    /// Rows here are `'\n'`-delimited, *not* visual wrap rows. Visual motion
+    /// would need the terminal width, which is main-thread state this buffer
+    /// cannot reach — and it would break history navigation for reader-mode
+    /// users specifically, since ReaderScreen never wraps: a long line would
+    /// leave the cursor on an invisible second row, so Up would move it
+    /// silently instead of recalling history.
+    fn step_up(&mut self) -> bool {
+        let (start, _) = self.logical_row_at(self.cursor_pos);
+        if start == 0 {
+            return false;
+        }
+        let column = self.cursor_pos - start;
+        let (prev_start, prev_len) = self.logical_row_at(start - 1);
+        self.cursor_pos = prev_start + column.min(prev_len);
+        true
+    }
+
+    /// Move to the same column on the next logical row.
+    fn step_down(&mut self) -> bool {
+        let (start, len) = self.logical_row_at(self.cursor_pos);
+        let end = start + len;
+        if end >= self.buffer.len() {
+            return false;
+        }
+        let column = self.cursor_pos - start;
+        let (next_start, next_len) = self.logical_row_at(end + 1);
+        self.cursor_pos = next_start + column.min(next_len);
+        true
     }
 
     fn step_right(&mut self) {
@@ -334,9 +388,23 @@ fn parse_key_event(
 ) {
     match key {
         Key::Char('\n') => {
-            let mut line = Line::from(buffer.submit());
-            line.flags.source = Some("user".to_string());
-            writer.send(Event::ServerInput(line)).unwrap();
+            // A Line carrying an embedded '\n' would be telnet-sent raw and
+            // would not match aliases, so the buffer fans out into one
+            // ServerInput per row, each running aliases/triggers/logging
+            // independently exactly as if it had been typed on its own.
+            //
+            // An empty buffer still emits exactly one blank line: "".split()
+            // yields [""], and MUD pagers depend on a bare Enter arriving.
+            let submitted = buffer.submit();
+            for (i, row) in submitted.split('\n').enumerate() {
+                let mut line = Line::from(row);
+                line.flags.source = Some("user".to_string());
+                // Only the first row cancels whatever speech is in flight; the
+                // rest queue behind it, so every row of a multi-row submit is
+                // actually heard.
+                line.flags.tts_interrupt = i == 0;
+                writer.send(Event::ServerInput(line)).unwrap();
+            }
             if let Ok(mut script) = script.lock() {
                 script.set_prompt_content(String::new(), 0);
             }
@@ -419,6 +487,12 @@ fn human_key(prefix: &str, c: char) -> String {
     match c {
         '\u{7f}' => out.push_str("backspace"),
         '\u{1b}' => out.push_str("escape"),
+        // Without this, Alt+Enter mints the binding name "alt-\n" — a literal
+        // newline — so blight.bind("alt-enter", ...) would never fire and the
+        // failure would be undiagnosable. Both carriage return and line feed
+        // are accepted because the ESC-prefix branch passes the raw byte
+        // through, and terminals differ on which one they send.
+        '\r' | '\n' => out.push_str("enter"),
         _ => out.push(c),
     }
     out
@@ -472,6 +546,13 @@ fn handle_script_ui_io(
             UiEvent::ScrollTop => writer.send(Event::ScrollTop).unwrap(),
             UiEvent::ScrollBottom => writer.send(Event::ScrollBottom).unwrap(),
             UiEvent::Complete => buffer.tab_complete(),
+            UiEvent::InsertNewline => buffer.push_key('\n'),
+            UiEvent::StepUp => {
+                buffer.step_up();
+            }
+            UiEvent::StepDown => {
+                buffer.step_down();
+            }
             UiEvent::Unknown(_) => {}
         });
         script.set_prompt_content(buffer.get_buffer(), buffer.get_pos());
@@ -750,6 +831,88 @@ mod command_test {
         assert_eq!(human_key("ctrl-", '\u{1b}'), "ctrl-escape");
         assert_eq!(human_key("ctrl-", 'd'), "ctrl-d");
         assert_eq!(human_key("f", 'x'), "fx");
+
+        // Without these, Alt+Enter mints "alt-\n" — a binding name containing a
+        // literal newline, which no user could write and which therefore never
+        // fires. Both forms, because terminals disagree on which byte they
+        // send and the ESC-prefix branch passes the raw byte through.
+        assert_eq!(human_key("alt-", '\r'), "alt-enter");
+        assert_eq!(human_key("alt-", '\n'), "alt-enter");
+        assert_eq!(human_key("ctrl-", '\r'), "ctrl-enter");
+    }
+
+    #[test]
+    fn test_step_up_down_between_logical_rows() {
+        let mut buffer = get_command().0;
+        push_string(&mut buffer, "one\ntwo\nthree");
+        assert_eq!(buffer.get_pos(), 13);
+
+        // Up from the last row keeps the column where the row is long enough.
+        assert!(buffer.step_up());
+        assert_eq!(buffer.get_pos(), 7); // end of "two"
+        assert!(buffer.step_up());
+        assert_eq!(buffer.get_pos(), 3); // clamped to the end of "one"
+
+        // At the first row there is nowhere to go, and the cursor must not
+        // move — that is what lets the binding fall through to history.
+        assert!(!buffer.step_up());
+        assert_eq!(buffer.get_pos(), 3);
+
+        assert!(buffer.step_down());
+        assert_eq!(buffer.get_pos(), 7);
+        assert!(buffer.step_down());
+        assert_eq!(buffer.get_pos(), 11);
+        assert!(!buffer.step_down());
+        assert_eq!(buffer.get_pos(), 11);
+    }
+
+    #[test]
+    fn test_step_up_down_clamps_to_short_rows() {
+        let mut buffer = get_command().0;
+        push_string(&mut buffer, "a\nlonger");
+        // Cursor at the end of "longer", column 6.
+        assert_eq!(buffer.get_pos(), 8);
+        assert!(buffer.step_up());
+        // "a" has only one column, so the cursor clamps to its end.
+        assert_eq!(buffer.get_pos(), 1);
+    }
+
+    #[test]
+    fn test_step_up_down_is_a_noop_without_row_breaks() {
+        let mut buffer = get_command().0;
+        push_string(&mut buffer, "no rows here");
+        let pos = buffer.get_pos();
+        assert!(!buffer.step_up());
+        assert!(!buffer.step_down());
+        assert_eq!(buffer.get_pos(), pos);
+    }
+
+    #[test]
+    fn test_insert_newline_via_push_key() {
+        let mut buffer = get_command().0;
+        push_string(&mut buffer, "ab");
+        buffer.push_key('\n');
+        push_string(&mut buffer, "cd");
+        assert_eq!(buffer.get_buffer(), "ab\ncd");
+        assert_eq!(buffer.get_pos(), 5);
+    }
+
+    /// Each row of a submitted buffer must become its own completion
+    /// candidate; a candidate containing a newline could never be typed back.
+    #[test]
+    fn test_submit_inserts_each_row_into_completions() {
+        let mut buffer = get_command().0;
+        push_string(&mut buffer, "northgate\nsouthgate");
+        buffer.submit();
+
+        push_string(&mut buffer, "north");
+        buffer.tab_complete();
+        assert_eq!(buffer.get_buffer(), "northgate");
+
+        buffer.clear();
+        push_string(&mut buffer, "south");
+        buffer.tab_complete();
+        assert_eq!(buffer.get_buffer(), "southgate");
     }
 
     #[test]

--- a/src/ui/command.rs
+++ b/src/ui/command.rs
@@ -109,6 +109,17 @@ impl CommandBuffer {
         self.cursor_pos
     }
 
+    /// The cursor position expressed in the coordinate space of
+    /// [`Self::get_masked_buffer`].
+    ///
+    /// `get_pos` indexes the raw buffer, so pairing it with the masked buffer
+    /// hands the renderer two different coordinate spaces — the bug class that
+    /// produced #742. Use this whenever the masked buffer is what gets drawn.
+    pub fn get_masked_pos(&self) -> usize {
+        self.prompt_mask
+            .masked_index(self.cursor_pos, self.buffer.len())
+    }
+
     fn submit(&mut self) -> String {
         // If we have no buffer then swap in the last buffer
         if self.last_command_enabled && self.buffer.is_empty() {

--- a/src/ui/headless_screen.rs
+++ b/src/ui/headless_screen.rs
@@ -96,6 +96,14 @@ impl UserInterface for HeadlessScreen {
         Ok(())
     }
 
+    fn set_input_height(&mut self, _height: u16) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn input_height(&self) -> u16 {
+        1
+    }
+
     fn set_show_tags(&mut self, _show: bool) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/ui/input_layout.rs
+++ b/src/ui/input_layout.rs
@@ -1,0 +1,384 @@
+//! Text arithmetic for the user input area: how a buffer divides into rows,
+//! where the cursor lands, and how tall the area wants to be.
+//!
+//! This is separated from [`super::split_screen`] for the same reason
+//! [`super::layout`] is: `SplitScreen::new` requires a real terminal, so
+//! anything computed inside it cannot be exercised in CI. Every piece of
+//! arithmetic lives here, where it is a pure function; the renderer stays a
+//! blitter.
+//!
+//! Two coordinate spaces meet here and must not be confused:
+//!
+//! * **byte** offsets, which is what [`rows`] returns, because they slice the
+//!   input directly;
+//! * **char** indices, which is what `CommandBuffer` counts in, and therefore
+//!   what [`cursor_row_col`] takes as `pos`.
+
+use std::ops::Range;
+
+use super::layout::{INPUT_HEIGHT_MAX, INPUT_HEIGHT_MIN};
+use super::user_interface::wrap_line_hard;
+use crate::tools::printable_chars::PrintableCharsIterator;
+
+/// Partition `input` into the visual rows it occupies in a `width`-column
+/// area, as byte ranges into `input`.
+///
+/// The ranges tile the input in order. `'\n'` characters are *not* part of any
+/// range — they are row separators, not content — so the ranges do not cover
+/// the whole string, but every non-newline byte belongs to exactly one.
+///
+/// Splitting on `'\n'` before wrapping is required, not stylistic:
+/// `PrintableChars` drives a vte parser whose `Performer` implements only
+/// `print`, so `'\n'` is a C0 control that is silently dropped. Measuring a
+/// buffer containing one would silently fuse two logical rows into one.
+pub fn rows(input: &str, width: u16) -> Vec<Range<usize>> {
+    let width = width.max(1) as usize;
+    let mut out: Vec<Range<usize>> = Vec::new();
+    let mut base = 0usize;
+
+    for segment in input.split('\n') {
+        let wrapped = wrap_line_hard(segment, width);
+        let last = wrapped.len() - 1; // `wrap_line_hard` never returns empty
+        let mut off = base;
+
+        for (i, row) in wrapped.iter().enumerate() {
+            out.push(off..off + row.len());
+            off += row.len();
+
+            // A logical row whose width is a nonzero exact multiple of the
+            // terminal width needs a trailing empty visual row. Without it a
+            // cursor sitting just past the last character addresses a row that
+            // does not exist — and this is precisely where a terminal puts it,
+            // since the cursor wraps to the next line rather than resting one
+            // column off the right edge.
+            if i == last && !row.is_empty() && row.display_width() >= width {
+                out.push(off..off);
+            }
+        }
+
+        base += segment.len() + 1; // `+ 1` for the '\n' that split consumed
+    }
+
+    out
+}
+
+/// Locate the flat **char** index `pos` as a `(row, column)` pair.
+///
+/// This is a lookup into [`rows`]'s partition rather than an independent
+/// `cumulative_width / width` calculation, and that matters:
+/// `byte_index_at_display_width` pushes a straddling double-width character
+/// forward onto the next row and leaves a hole in the one it left. A parallel
+/// reconstruction disagrees at every such hole by a full row, which renders
+/// the cursor a line away from the character it is editing.
+pub fn cursor_row_col(input: &str, pos: usize, width: u16) -> (u16, u16) {
+    let rows = rows(input, width);
+    let byte_off = char_to_byte(input, pos);
+
+    // The last row that starts at or before the cursor. `rows` is ordered and
+    // may contain empty ranges, so this is a scan rather than a search on
+    // containment — an empty range contains nothing.
+    let mut idx = 0;
+    for (i, row) in rows.iter().enumerate() {
+        if row.start <= byte_off {
+            idx = i;
+        } else {
+            break;
+        }
+    }
+
+    let row = &rows[idx];
+    let end = byte_off.clamp(row.start, row.end);
+    let before = &input[row.start..end];
+    let col = before.display_width();
+
+    (idx as u16, col as u16)
+}
+
+/// Byte offset of the `pos`-th character, saturating at the end of `input`.
+fn char_to_byte(input: &str, pos: usize) -> usize {
+    input
+        .char_indices()
+        .nth(pos)
+        .map(|(i, _)| i)
+        .unwrap_or(input.len())
+}
+
+/// How many rows the input area wants, given how many the content occupies.
+///
+/// `configured` is a *minimum*, not a fixed size: with auto-expand off it is
+/// the height, and with it on the area grows past it as content requires and
+/// shrinks back. One number, no mode enum.
+pub fn desired_height(row_count: usize, configured: u16, auto_expand: bool) -> u16 {
+    let configured = configured.clamp(INPUT_HEIGHT_MIN, INPUT_HEIGHT_MAX);
+    if auto_expand {
+        let rows = u16::try_from(row_count).unwrap_or(u16::MAX);
+        rows.clamp(configured, INPUT_HEIGHT_MAX)
+    } else {
+        configured
+    }
+}
+
+/// Which rows are on screen when the content is taller than the input area.
+///
+/// The cursor's row is always within the returned range; the window is pinned
+/// to the bottom of the content once it reaches the end.
+pub fn visible_rows(row_count: usize, cursor_row: usize, height: u16) -> Range<usize> {
+    let height = height.max(INPUT_HEIGHT_MIN) as usize;
+    if row_count <= height {
+        return 0..row_count;
+    }
+
+    let max_start = row_count - height;
+    let start = cursor_row.saturating_sub(height - 1).min(max_start);
+    start..start + height
+}
+
+#[cfg(test)]
+mod input_layout_test {
+    use super::*;
+
+    fn row_strs(input: &str, width: u16) -> Vec<&str> {
+        rows(input, width)
+            .into_iter()
+            .map(|r| &input[r])
+            .collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn plain_line_shorter_than_width_is_one_row() {
+        assert_eq!(row_strs("hello", 20), vec!["hello"]);
+    }
+
+    #[test]
+    fn empty_input_is_one_empty_row() {
+        assert_eq!(row_strs("", 20), vec![""]);
+    }
+
+    #[test]
+    fn newlines_start_new_rows_and_are_not_content() {
+        assert_eq!(row_strs("a\nb\nc", 20), vec!["a", "b", "c"]);
+        // A trailing newline opens an empty row the cursor can sit on.
+        assert_eq!(row_strs("a\n", 20), vec!["a", ""]);
+        // Consecutive newlines produce genuinely blank rows.
+        assert_eq!(row_strs("a\n\nb", 20), vec!["a", "", "b"]);
+    }
+
+    #[test]
+    fn long_line_wraps_losslessly() {
+        assert_eq!(row_strs("abcdefgh", 3), vec!["abc", "def", "gh"]);
+    }
+
+    /// The guard the plan calls out: at an exact multiple of the width there
+    /// must be a row for the cursor to wrap onto.
+    #[test]
+    fn exact_multiple_of_width_gets_a_trailing_empty_row() {
+        assert_eq!(row_strs("abc", 3), vec!["abc", ""]);
+        assert_eq!(row_strs("abcdef", 3), vec!["abc", "def", ""]);
+        // ...but only at the end of a logical row, not at every break.
+        assert_eq!(row_strs("abcd", 3), vec!["abc", "d"]);
+        // ...and not for an empty row, which is already the cursor's row.
+        assert_eq!(row_strs("", 3), vec![""]);
+    }
+
+    #[test]
+    fn wide_characters_wrap_by_display_width_not_char_count() {
+        // Each CJK glyph is two columns, so only two fit in five.
+        assert_eq!(row_strs("中文中文", 5), vec!["中文", "中文"]);
+    }
+
+    /// A glyph wider than the whole area must not spin the wrap loop. Each
+    /// glyph overflows its row by a column, and the trailing empty row still
+    /// appears — the cursor cannot rest in the overflowed column, so it needs
+    /// somewhere to go.
+    #[test]
+    fn glyph_wider_than_area_terminates() {
+        assert_eq!(row_strs("中文", 1), vec!["中", "文", ""]);
+        assert_eq!(cursor_row_col("中文", 2, 1), (2, 0));
+    }
+
+    /// Escape sequences occupy no columns and must not force a wrap.
+    #[test]
+    fn escapes_consume_no_columns() {
+        let input = "\x1b[31mabcde\x1b[0m";
+        assert_eq!(rows(input, 5).len(), 2); // content row + wrap row
+        assert_eq!(&input[rows(input, 5)[0].clone()], input);
+    }
+
+    /// Every byte except the row separators belongs to exactly one row, and
+    /// the rows are in order. This is the property the cursor depends on.
+    #[test]
+    fn rows_partition_the_input() {
+        for input in [
+            "",
+            "a",
+            "hello world",
+            "a\nb",
+            "a\n\nb\n",
+            "\n\n\n",
+            "中文test中文",
+            "\x1b[31mred\x1b[0m text",
+            "trailing   ",
+        ] {
+            for width in 1..=12u16 {
+                let rows = rows(input, width);
+                assert!(!rows.is_empty(), "{input:?} @ {width} produced no rows");
+
+                let mut expected = 0usize;
+                for row in &rows {
+                    assert!(row.start >= expected, "rows out of order in {input:?}");
+                    assert!(row.end >= row.start);
+                    assert!(row.end <= input.len());
+                    // Only a '\n' may be skipped between rows.
+                    if row.start > expected {
+                        assert_eq!(
+                            &input[expected..row.start],
+                            "\n",
+                            "unexpected gap in {input:?} @ {width}"
+                        );
+                    }
+                    expected = row.end;
+                }
+
+                let joined: String = rows.iter().map(|r| &input[r.clone()]).collect();
+                assert_eq!(
+                    joined,
+                    input.replace('\n', ""),
+                    "lost content in {input:?} @ {width}"
+                );
+            }
+        }
+    }
+
+    /// `cursor_row_col` is asserted against `rows()` rather than hand-written
+    /// expectations, so the two cannot drift apart. Every cursor position in
+    /// every buffer at every width must land on a row that exists, at a column
+    /// that row actually reaches.
+    #[test]
+    fn cursor_is_always_inside_a_real_row() {
+        for input in [
+            "",
+            "a",
+            "hello world",
+            "a\nb\nc",
+            "a\n\nb\n",
+            "中文test中文",
+            "\x1b[31mred\x1b[0m text",
+            "abc",
+            "abcdef",
+        ] {
+            for width in 1..=12u16 {
+                let rows = rows(input, width);
+                for pos in 0..=input.chars().count() {
+                    let (row, col) = cursor_row_col(input, pos, width);
+
+                    assert!(
+                        (row as usize) < rows.len(),
+                        "cursor row {row} out of range for {input:?} @ {width} pos {pos}"
+                    );
+
+                    let text = &input[rows[row as usize].clone()];
+                    assert!(
+                        col as usize <= text.display_width(),
+                        "cursor col {col} past end of row {row} ({text:?}) \
+                         for {input:?} @ {width} pos {pos}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn cursor_at_start_is_row_zero_column_zero() {
+        assert_eq!(cursor_row_col("hello", 0, 20), (0, 0));
+        assert_eq!(cursor_row_col("", 0, 20), (0, 0));
+    }
+
+    #[test]
+    fn cursor_tracks_logical_rows() {
+        let input = "ab\ncd";
+        assert_eq!(cursor_row_col(input, 2, 20), (0, 2)); // end of "ab"
+        assert_eq!(cursor_row_col(input, 3, 20), (1, 0)); // start of "cd"
+        assert_eq!(cursor_row_col(input, 5, 20), (1, 2)); // end of "cd"
+    }
+
+    #[test]
+    fn cursor_wraps_onto_the_trailing_empty_row() {
+        // "abc" exactly fills a 3-column area; the cursor after it belongs on
+        // the next row, which is why that row is generated at all.
+        assert_eq!(cursor_row_col("abc", 3, 3), (1, 0));
+        assert_eq!(cursor_row_col("abc", 2, 3), (0, 2));
+    }
+
+    #[test]
+    fn cursor_column_counts_display_width() {
+        // Two CJK glyphs are two chars but four columns.
+        assert_eq!(cursor_row_col("中文test", 2, 20), (0, 4));
+    }
+
+    /// A position past the end of the buffer must clamp, not panic.
+    #[test]
+    fn cursor_past_end_clamps() {
+        let (row, col) = cursor_row_col("abc", 99, 20);
+        assert_eq!((row, col), (0, 3));
+    }
+
+    #[test]
+    fn desired_height_is_the_configured_value_when_not_expanding() {
+        assert_eq!(desired_height(1, 3, false), 3);
+        assert_eq!(desired_height(9, 3, false), 3);
+        assert_eq!(desired_height(1, 1, false), 1);
+    }
+
+    #[test]
+    fn desired_height_grows_and_shrinks_when_expanding() {
+        assert_eq!(desired_height(1, 1, true), 1);
+        assert_eq!(desired_height(4, 1, true), 4);
+        // Never below the configured minimum...
+        assert_eq!(desired_height(1, 3, true), 3);
+        // ...and never above the hard maximum.
+        assert_eq!(desired_height(500, 1, true), INPUT_HEIGHT_MAX);
+        assert_eq!(desired_height(usize::MAX, 1, true), INPUT_HEIGHT_MAX);
+    }
+
+    #[test]
+    fn desired_height_clamps_a_nonsense_configuration() {
+        assert_eq!(desired_height(1, 0, false), INPUT_HEIGHT_MIN);
+        assert_eq!(desired_height(1, 500, false), INPUT_HEIGHT_MAX);
+    }
+
+    #[test]
+    fn all_rows_visible_when_they_fit() {
+        assert_eq!(visible_rows(3, 0, 5), 0..3);
+        assert_eq!(visible_rows(3, 2, 3), 0..3);
+        assert_eq!(visible_rows(0, 0, 3), 0..0);
+    }
+
+    #[test]
+    fn visible_window_follows_the_cursor() {
+        // 10 rows in a 3-row area.
+        assert_eq!(visible_rows(10, 0, 3), 0..3);
+        assert_eq!(visible_rows(10, 2, 3), 0..3);
+        assert_eq!(visible_rows(10, 3, 3), 1..4);
+        assert_eq!(visible_rows(10, 9, 3), 7..10);
+    }
+
+    /// The window must contain the cursor for every combination, or the user
+    /// types into a row they cannot see.
+    #[test]
+    fn visible_window_always_contains_the_cursor() {
+        for row_count in 1..30usize {
+            for height in 1..12u16 {
+                for cursor in 0..row_count {
+                    let window = visible_rows(row_count, cursor, height);
+                    assert!(
+                        window.contains(&cursor),
+                        "cursor {cursor} outside {window:?} \
+                         (rows {row_count}, height {height})"
+                    );
+                    assert!(window.end <= row_count);
+                    assert!(window.len() <= height as usize);
+                }
+            }
+        }
+    }
+}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,0 +1,290 @@
+//! Vertical screen layout arithmetic for [`super::SplitScreen`].
+//!
+//! `SplitScreen::new` needs a real terminal, so anything computed inside it
+//! cannot be exercised in CI. The row arithmetic lives here instead, as a pure
+//! function of the terminal height and the configured region sizes, so it can
+//! be tested directly.
+//!
+//! The screen is divided top to bottom:
+//!
+//! ```text
+//! 1                    ┐
+//! ..                   │ top area (`top_rows` rows, may be 0)
+//! top_rows             ┘
+//! output_start_line    ┐
+//! ..                   │ output / scroll region (DECSTBM)
+//! output_line          ┘
+//! mud_prompt_line        the MUD's own prompt (always exactly 1 row)
+//! ..                   ┐ status area (`status_height` rows, may be 0)
+//! ..                   ┘
+//! input_start_line     ┐
+//! ..                   │ user input area (`input_height` rows, at least 1)
+//! term_height          ┘
+//! ```
+
+/// The scroll region is programmed with DECSTBM (`CSI Pt ; Pb r`), which
+/// requires `Pt < Pb` — a region must span at least two rows. A terminal
+/// silently *discards* an out-of-range request rather than reporting an error,
+/// leaving whatever region was previously in effect; output written afterwards
+/// then scrolls the whole screen and drags the status and input areas with it.
+/// So a layout that cannot give the output region two rows is not renderable at
+/// all, and must be rejected rather than clamped.
+pub const MIN_OUTPUT_ROWS: u16 = 2;
+
+/// An input area is never zero rows — there would be nowhere to type.
+pub const INPUT_HEIGHT_MIN: u16 = 1;
+
+/// Upper bound on a user-requested input height, mirroring `STATUS_HEIGHT_MAX`.
+pub const INPUT_HEIGHT_MAX: u16 = 10;
+
+/// Absolute, 1-based terminal row numbers for each region boundary.
+///
+/// Produced only by [`ScreenLayout::compute`], which guarantees the invariants
+/// the renderer relies on — most importantly that the output region is valid to
+/// program as a scroll region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScreenLayout {
+    /// First row of the output/scroll region.
+    pub output_start_line: u16,
+    /// Last row of the output/scroll region.
+    pub output_line: u16,
+    /// The row carrying the MUD's own prompt.
+    pub mud_prompt_line: u16,
+    /// First row of the user input area.
+    pub input_start_line: u16,
+    /// Rows granted to the input area. May be less than requested.
+    pub input_height: u16,
+    /// Rows granted to the status area. May be less than requested.
+    pub status_height: u16,
+}
+
+impl ScreenLayout {
+    /// Divide a terminal `term_height` rows tall between the regions.
+    ///
+    /// `input_height` and `status_height` are *requests*. When the terminal is
+    /// too short to honour them, they are reduced in that order — the input
+    /// area shrinks toward [`INPUT_HEIGHT_MIN`] first, then the status area
+    /// toward zero — so that the output region keeps [`MIN_OUTPUT_ROWS`].
+    ///
+    /// Returns `None` when even the minimal layout does not fit, which the
+    /// caller must treat as "do not render", not as "render something".
+    pub fn compute(
+        term_height: u16,
+        top_rows: u16,
+        status_height: u16,
+        input_height: u16,
+    ) -> Option<Self> {
+        let output_start_line = top_rows.checked_add(1)?;
+
+        // Rows left for the output region, the MUD prompt, the status area and
+        // the input area once the top area has taken its share.
+        let budget = term_height.checked_sub(top_rows)?;
+
+        // The MUD prompt row, the minimum output region and the one row the
+        // input area is always entitled to are not negotiable; whatever remains
+        // is what the two configurable regions may share.
+        let fixed = MIN_OUTPUT_ROWS + 1 + INPUT_HEIGHT_MIN;
+        let spare = budget.checked_sub(fixed)?;
+
+        let mut input_height = input_height.clamp(INPUT_HEIGHT_MIN, INPUT_HEIGHT_MAX);
+        let mut status_height = status_height;
+
+        // Only the rows *beyond* the guaranteed minimum are drawn from `spare`.
+        if input_height - INPUT_HEIGHT_MIN + status_height > spare {
+            // Shrink the input area first, down to its minimum.
+            let overflow = input_height - INPUT_HEIGHT_MIN + status_height - spare;
+            let give = overflow.min(input_height - INPUT_HEIGHT_MIN);
+            input_height -= give;
+
+            // Then the status area, down to nothing.
+            let overflow = overflow - give;
+            status_height = status_height.saturating_sub(overflow);
+        }
+
+        // `spare` already reserved MIN_OUTPUT_ROWS, so the output region grows
+        // into whatever the configurable regions did not take.
+        let output_rows =
+            MIN_OUTPUT_ROWS + spare - (input_height - INPUT_HEIGHT_MIN) - status_height;
+
+        let output_line = output_start_line + output_rows - 1;
+        let mud_prompt_line = output_line + 1;
+        let input_start_line = mud_prompt_line + status_height + 1;
+
+        let layout = Self {
+            output_start_line,
+            output_line,
+            mud_prompt_line,
+            input_start_line,
+            input_height,
+            status_height,
+        };
+
+        debug_assert!(layout.is_scroll_region_valid());
+        debug_assert_eq!(
+            layout.input_start_line + layout.input_height - 1,
+            term_height,
+            "input area must end on the last terminal row"
+        );
+
+        Some(layout)
+    }
+
+    /// Whether the output region may be programmed with DECSTBM.
+    ///
+    /// [`Self::compute`] never produces a layout for which this is false; it is
+    /// exposed so the renderer can assert the invariant at the point of use.
+    pub fn is_scroll_region_valid(&self) -> bool {
+        self.output_line > self.output_start_line
+    }
+
+    /// Number of rows in the output region.
+    ///
+    /// `SplitScreen::output_range` is the production spelling of this; it reads
+    /// the boundaries this type produced, so the two cannot disagree.
+    #[cfg(test)]
+    pub fn output_rows(&self) -> u16 {
+        self.output_line - self.output_start_line + 1
+    }
+}
+
+#[cfg(test)]
+mod layout_test {
+    use super::*;
+
+    /// The arithmetic this module replaces, as it stood in `setup()`:
+    ///   output_line     = height - status - 2
+    ///   mud_prompt_line = height - status - 1
+    ///   prompt_line     = height
+    /// with `output_start_line = top_rows + 1`. A single-row input area must
+    /// still produce exactly those numbers.
+    #[test]
+    fn default_layout_matches_legacy_arithmetic() {
+        for height in [24_u16, 40, 50, 80] {
+            for top_rows in [1_u16, 2] {
+                for status in [0_u16, 1, 3, 5] {
+                    let layout = ScreenLayout::compute(height, top_rows, status, 1).unwrap();
+                    assert_eq!(layout.output_start_line, top_rows + 1);
+                    assert_eq!(layout.output_line, height - status - 2);
+                    assert_eq!(layout.mud_prompt_line, height - status - 1);
+                    assert_eq!(layout.input_start_line, height);
+                    assert_eq!(layout.status_height, status);
+                }
+            }
+        }
+    }
+
+    /// `height - status - 2` underflows once the status area and top rows
+    /// consume the terminal. Previously a debug-build panic.
+    #[test]
+    fn short_terminal_does_not_underflow() {
+        // Every one of these is a raw-subtraction panic in the old arithmetic.
+        assert!(ScreenLayout::compute(3, 1, 1, 1).is_none());
+        assert!(ScreenLayout::compute(2, 1, 0, 1).is_none());
+        assert!(ScreenLayout::compute(1, 1, 0, 1).is_none());
+        assert!(ScreenLayout::compute(0, 0, 0, 1).is_none());
+    }
+
+    /// `status_height` clamps to 5, so a 6-row terminal with a full status area
+    /// drove `self.height - height - PROMPT_HEIGHT` negative.
+    #[test]
+    fn status_height_five_on_six_row_terminal_leaves_output() {
+        let layout = ScreenLayout::compute(6, 1, 5, 1).unwrap();
+        assert!(layout.is_scroll_region_valid());
+        assert!(layout.output_rows() >= MIN_OUTPUT_ROWS);
+        // The status area gave up rows so the output region stayed valid.
+        assert!(layout.status_height < 5);
+    }
+
+    /// Precedence: the input area yields before the status area does.
+    #[test]
+    fn input_height_squeezes_before_status_starves() {
+        // 12 rows, 1 top row, status 3, input 5 -> needs 1+2+1+3+5 = 12, fits.
+        let layout = ScreenLayout::compute(12, 1, 3, 5).unwrap();
+        assert_eq!(layout.input_height, 5);
+        assert_eq!(layout.status_height, 3);
+
+        // One row tighter: the input area is what gives.
+        let layout = ScreenLayout::compute(11, 1, 3, 5).unwrap();
+        assert_eq!(layout.input_height, 4);
+        assert_eq!(layout.status_height, 3);
+
+        // Tighter still: input bottoms out at 1, then status starts yielding.
+        let layout = ScreenLayout::compute(8, 1, 3, 5).unwrap();
+        assert_eq!(layout.input_height, INPUT_HEIGHT_MIN);
+        assert_eq!(layout.status_height, 3);
+
+        let layout = ScreenLayout::compute(7, 1, 3, 5).unwrap();
+        assert_eq!(layout.input_height, INPUT_HEIGHT_MIN);
+        assert_eq!(layout.status_height, 2);
+    }
+
+    /// The regions must tile the terminal exactly, with no gap and no overlap,
+    /// for every layout `compute` is willing to return.
+    #[test]
+    fn regions_tile_the_terminal_exactly() {
+        for height in 0_u16..64 {
+            for top_rows in 0_u16..4 {
+                for status in 0_u16..6 {
+                    for input in 1_u16..12 {
+                        let Some(layout) = ScreenLayout::compute(height, top_rows, status, input)
+                        else {
+                            continue;
+                        };
+
+                        assert_eq!(layout.output_start_line, top_rows + 1);
+                        assert_eq!(layout.mud_prompt_line, layout.output_line + 1);
+                        assert_eq!(
+                            layout.input_start_line,
+                            layout.mud_prompt_line + layout.status_height + 1
+                        );
+                        assert_eq!(layout.input_start_line + layout.input_height - 1, height);
+
+                        assert!(layout.input_height >= INPUT_HEIGHT_MIN);
+                        assert!(layout.input_height <= input.max(INPUT_HEIGHT_MIN));
+                        assert!(layout.status_height <= status);
+                    }
+                }
+            }
+        }
+    }
+
+    /// The reason `compute` returns `Option` at all: a scroll region with
+    /// `bottom <= top` is discarded by the terminal, which is worse than not
+    /// rendering, because the previous region silently stays in force.
+    #[test]
+    fn scroll_region_is_never_emitted_with_bottom_le_top() {
+        for height in 0_u16..64 {
+            for top_rows in 0_u16..4 {
+                for status in 0_u16..6 {
+                    for input in 1_u16..12 {
+                        if let Some(layout) = ScreenLayout::compute(height, top_rows, status, input)
+                        {
+                            assert!(
+                                layout.is_scroll_region_valid(),
+                                "invalid scroll region {}..{} from ({height}, {top_rows}, {status}, {input})",
+                                layout.output_start_line,
+                                layout.output_line,
+                            );
+                            assert!(layout.output_rows() >= MIN_OUTPUT_ROWS);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// A request above the maximum is clamped, not rejected.
+    #[test]
+    fn input_height_clamps_to_max() {
+        let layout = ScreenLayout::compute(80, 1, 1, 500).unwrap();
+        assert_eq!(layout.input_height, INPUT_HEIGHT_MAX);
+    }
+
+    /// A zero request is raised to the minimum rather than leaving nowhere to
+    /// type.
+    #[test]
+    fn input_height_zero_is_raised_to_minimum() {
+        let layout = ScreenLayout::compute(80, 1, 1, 0).unwrap();
+        assert_eq!(layout.input_height, INPUT_HEIGHT_MIN);
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,6 +5,7 @@ pub use self::{
     headless_screen::HeadlessScreen,
     help_handler::HelpHandler,
     history::History,
+    layout::{INPUT_HEIGHT_MAX, INPUT_HEIGHT_MIN},
     reader_screen::ReaderScreen,
     split_screen::SplitScreen,
     top_area::{TopPrefix, TopPrefixStyle, TopRowBody, TopRowOpts, TopRowSelector},

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,6 +20,8 @@ mod command;
 mod headless_screen;
 mod help_handler;
 mod history;
+mod input_layout;
+mod layout;
 mod reader_screen;
 mod scroll_data;
 mod split_screen;

--- a/src/ui/reader_screen.rs
+++ b/src/ui/reader_screen.rs
@@ -225,6 +225,23 @@ impl UserInterface for ReaderScreen {
 
     // This is fancy logic to make 'tdsr' less noisy
     fn print_prompt_input(&mut self, input: &str, pos: usize) {
+        // Row breaks must be substituted *before* the sanitize below. The vte
+        // parser behind `printable_chars` routes '\n' to `execute`, not
+        // `print`, so it is silently dropped and "one\ntwo" would be read out
+        // as "onetwo". This is a fix, not just a guard.
+        //
+        // The substitute is exactly one char of exactly one display column,
+        // because `pos` indexes the pre-substitution buffer and the column
+        // computed below is treated as an absolute terminal column. In reader
+        // mode that column *is* the screen reader's anchor, so a one-column
+        // drift is a mis-announcement rather than a cosmetic glitch. A space
+        // avoids depending on how espeak, macOS `say` or NVDA pronounce a
+        // glyph.
+        const ROW_BREAK: char = ' ';
+        debug_assert_eq!(unicode_width::UnicodeWidthChar::width(ROW_BREAK), Some(1));
+        let input = input.replace('\n', &ROW_BREAK.to_string());
+        let input = input.as_str();
+
         // Reader screens only operate on printable input characters (no term control sequences, e.g. ANSI colour).
         let sanitized_input = input.printable_chars().collect::<String>();
         let input = sanitized_input.as_str();
@@ -435,6 +452,17 @@ impl UserInterface for ReaderScreen {
         Ok(())
     }
 
+    /// Reader mode stays one row tall: a screen reader gains nothing from
+    /// a taller box, and the minimal-diff logic assumes a single-line
+    /// model. Row breaks are rendered as a marker instead.
+    fn set_input_height(&mut self, _height: u16) -> Result<()> {
+        Ok(())
+    }
+
+    fn input_height(&self) -> u16 {
+        1
+    }
+
     fn set_show_tags(&mut self, _show: bool) -> Result<()> {
         Ok(())
     }
@@ -501,5 +529,91 @@ impl UserInterface for ReaderScreen {
         // Reader mode skips the tab indicator (it's a screen-reader-friendly
         // single-stream view). The active tab still drives what's read.
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod reader_screen_test {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    // `ReaderScreen::new` needs a real terminal, but `print_prompt_input` only
+    // needs `&mut self` and a `Box<dyn Write>`, so a capturing writer gets the
+    // diff logic under test without a TTY. Reader mode had no automated
+    // coverage at all before this; an untested path is a second-class path
+    // regardless of intent.
+
+    #[derive(Clone)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn test_screen() -> (ReaderScreen, Arc<Mutex<Vec<u8>>>) {
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let screen = ReaderScreen {
+            screen: Box::new(SharedBuf(sink.clone())),
+            history: History::new(),
+            scroll_data: ScrollData::new(),
+            output_line: 23,
+            prompt_line: 24,
+            width: 40,
+            height: 24,
+            prompt_input: None,
+        };
+        (screen, sink)
+    }
+
+    fn rendered(sink: &Arc<Mutex<Vec<u8>>>) -> String {
+        String::from_utf8(sink.lock().unwrap().clone()).unwrap()
+    }
+
+    /// vte routes '\n' to `execute`, not `print`, so `printable_chars` drops it
+    /// silently — two rows would run together as one word. The substitution has
+    /// to happen before that sanitize.
+    #[test]
+    fn row_breaks_are_substituted_not_dropped() {
+        let (mut screen, sink) = test_screen();
+        screen.print_prompt_input("one\ntwo", 7);
+
+        let out = rendered(&sink);
+        assert!(
+            out.contains("one two"),
+            "row break was dropped, giving {out:?}"
+        );
+        assert!(!out.contains("onetwo"));
+    }
+
+    /// The substitute must be one character of one column. `pos` indexes the
+    /// pre-substitution buffer and the column below is treated as an absolute
+    /// terminal column, which in reader mode is the screen reader's anchor —
+    /// a one-column drift is a mis-announcement, not a cosmetic glitch.
+    #[test]
+    fn row_break_does_not_shift_the_cursor_column() {
+        let (mut screen, _sink) = test_screen();
+        screen.print_prompt_input("one\ntwo", 7);
+        let (_, with_break) = screen.prompt_input.clone().unwrap();
+
+        let (mut screen, _sink) = test_screen();
+        screen.print_prompt_input("one two", 7);
+        let (_, without_break) = screen.prompt_input.clone().unwrap();
+
+        assert_eq!(with_break, without_break);
+    }
+
+    /// Reader mode stays one row tall whatever is requested, and says so.
+    #[test]
+    fn input_height_is_always_one() {
+        let (mut screen, _sink) = test_screen();
+        assert_eq!(screen.input_height(), 1);
+        screen.set_input_height(5).unwrap();
+        assert_eq!(screen.input_height(), 1);
     }
 }

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -1,6 +1,6 @@
 use super::history::History;
 use super::input_layout;
-use super::layout::{ScreenLayout, INPUT_HEIGHT_MIN};
+use super::layout::{ScreenLayout, INPUT_HEIGHT_MAX, INPUT_HEIGHT_MIN};
 use super::scroll_data::ScrollData;
 use super::top_area::{
     self, row_names, TopArea, TopPrefix, TopPrefixStyle, TopRenderContext, TopRowBody,
@@ -9,7 +9,8 @@ use super::user_interface::TerminalSizeError;
 use super::wrap_line;
 use crate::io::SaveData;
 use crate::model::{
-    Settings, HIDE_TOPBAR, TAB_INDICATOR_BRAND, TAB_INDICATOR_INLINE, TAB_INDICATOR_VISIBLE,
+    Settings, HIDE_TOPBAR, INPUT_AUTO_EXPAND, TAB_INDICATOR_BRAND, TAB_INDICATOR_INLINE,
+    TAB_INDICATOR_VISIBLE,
 };
 use crate::tabs::TabInfo;
 use crate::{
@@ -25,7 +26,6 @@ use termion::cursor;
 use super::UserInterface;
 
 const SCROLL_LIVE_BUFFER_SIZE: u16 = 10;
-const PROMPT_HEIGHT: u16 = 1;
 const STATUS_HEIGHT_MIN: u16 = 0;
 const STATUS_HEIGHT_MAX: u16 = 5;
 
@@ -151,10 +151,13 @@ pub struct SplitScreen {
     /// Cursor row *within* the input area, counted from `prompt_line`. Always
     /// zero while the input area is one row tall.
     cursor_prompt_row: u16,
-    /// Rows granted to the user input area. Pinned at [`INPUT_HEIGHT_MIN`]
-    /// until the height plumbing lands; the multi-row render path below is
-    /// therefore compiled but not yet reachable.
+    /// Rows the input area currently occupies. With auto-expand off this
+    /// equals `input_height_setting`; with it on it grows above it.
     input_height: u16,
+    /// The configured *minimum* row count — what `blight.input_height(n)` set.
+    /// Kept separate from `input_height` so that auto-expand can shrink back
+    /// to the user's floor rather than to one row.
+    input_height_setting: u16,
     /// Whether the input area grows past `input_height` as content requires.
     input_auto_expand: bool,
     history: History,
@@ -232,10 +235,15 @@ impl UserInterface for SplitScreen {
                 height,
                 self.top_area.visible_row_count(),
                 self.status_area.height(),
-                INPUT_HEIGHT_MIN,
+                self.input_height,
             )
             .ok_or(TerminalSizeError)?;
 
+            // The layout is free to grant fewer rows than were requested. Take
+            // what it gave, so `input_height()` reports the truth to NAWS
+            // rather than echoing back what Lua asked for.
+            self.input_height = layout.input_height;
+            self.input_auto_expand = settings.get(INPUT_AUTO_EXPAND)?;
             self.output_start_line = layout.output_start_line;
             self.output_line = layout.output_line;
             self.mud_prompt_line = layout.mud_prompt_line;
@@ -326,6 +334,20 @@ impl UserInterface for SplitScreen {
 
         self.prompt_input = input.to_string();
         self.prompt_input_pos = pos;
+
+        if self.input_auto_expand {
+            let row_count = input_layout::rows(input, self.width).len();
+            let wanted = input_layout::desired_height(row_count, self.input_height_setting, true);
+            if wanted != self.input_height {
+                // Deliberately not `setup()`. That opens with `reset()` —
+                // clear::All plus ResetScrollRegion — then reloads settings
+                // from disk and repaints with a flush in between, i.e. a
+                // blank-then-content two-frame sequence. Acceptable on a
+                // resize; unacceptable on the keystroke that happens to wrap
+                // to a new row, which is when auto-expand fires.
+                self.resize_input_area(wanted).ok();
+            }
+        }
 
         if self.input_height > INPUT_HEIGHT_MIN {
             self.print_prompt_input_rows(input, pos);
@@ -617,12 +639,40 @@ impl UserInterface for SplitScreen {
 
     fn set_status_area_height(&mut self, height: u16) -> Result<()> {
         let height = StatusArea::clamp_height(height) as u16;
-        self.status_area
-            .set_height(height, self.height - height - PROMPT_HEIGHT);
+        // `setup()` recomputes the real start line from the layout a moment
+        // later, so this only has to be in range rather than correct — but it
+        // used to be a raw subtraction, and a status height of 5 on a six-row
+        // terminal drove it negative.
+        self.status_area.set_height(
+            height,
+            self.height
+                .saturating_sub(height)
+                .saturating_sub(self.input_height),
+        );
         self.setup()?;
         let input_str = self.prompt_input.as_str().to_owned();
         self.print_prompt_input(&input_str, self.prompt_input_pos);
         Ok(())
+    }
+
+    fn set_input_height(&mut self, height: u16) -> Result<()> {
+        let height = height.clamp(INPUT_HEIGHT_MIN, INPUT_HEIGHT_MAX);
+        self.input_height_setting = height;
+        if height == self.input_height {
+            return Ok(());
+        }
+        self.input_height = height;
+        self.setup()?;
+        let input_str = self.prompt_input.as_str().to_owned();
+        self.print_prompt_input(&input_str, self.prompt_input_pos);
+        Ok(())
+    }
+
+    fn input_height(&self) -> u16 {
+        // The layout may have granted fewer rows than were asked for, so this
+        // reports what the screen actually has. NAWS depends on the
+        // difference.
+        self.input_height
     }
 
     fn set_show_tags(&mut self, show: bool) -> Result<()> {
@@ -791,6 +841,7 @@ impl SplitScreen {
             cursor_prompt_pos: 1,
             cursor_prompt_row: 0,
             input_height: layout.input_height,
+            input_height_setting: layout.input_height,
             input_auto_expand: false,
             history,
             scroll_data: ScrollData::new(),
@@ -838,12 +889,57 @@ impl SplitScreen {
         }
     }
 
+    /// Re-lay-out for a new input height without going through `setup()`.
+    ///
+    /// Re-emits the scroll region and repaints the regions whose rows changed
+    /// ownership, but never clears the screen and never touches the settings
+    /// file. Returns without drawing anything when the layout cannot honour
+    /// the new height, leaving the previous one in force.
+    fn resize_input_area(&mut self, height: u16) -> Result<()> {
+        let Some(layout) = ScreenLayout::compute(
+            self.height,
+            self.top_area.visible_row_count(),
+            self.status_area.height(),
+            height,
+        ) else {
+            return Ok(());
+        };
+
+        if layout.input_height == self.input_height {
+            return Ok(());
+        }
+
+        self.input_height = layout.input_height;
+        self.output_start_line = layout.output_start_line;
+        self.output_line = layout.output_line;
+        self.mud_prompt_line = layout.mud_prompt_line;
+        self.prompt_line = layout.input_start_line;
+
+        write!(
+            self.screen,
+            "{}{}",
+            ScrollRegion(self.output_start_line, self.output_line),
+            DisableOriginMode
+        )?;
+
+        // Rows moved between the output, status and input regions, so each has
+        // to repaint over whatever the other used to own.
+        self.reset_scroll()?;
+        self.redraw_prompt();
+        self.redraw_status_area()?;
+        Ok(())
+    }
+
     /// The height the input area wants for `row_count` rows of content.
     ///
     /// With auto-expand off this is just the configured height, which is why
     /// wiring it up now changes nothing.
     fn effective_input_height(&self, row_count: usize) -> u16 {
-        input_layout::desired_height(row_count, self.input_height, self.input_auto_expand)
+        input_layout::desired_height(
+            row_count,
+            self.input_height_setting.max(self.input_height),
+            self.input_auto_expand,
+        )
     }
 
     /// Paint the input area as wrapped rows. Used when the area is taller than
@@ -1267,6 +1363,7 @@ mod screen_test {
             cursor_prompt_pos: 1,
             cursor_prompt_row: 0,
             input_height: layout.input_height,
+            input_height_setting: layout.input_height,
             input_auto_expand: false,
             history: History::new(),
             scroll_data: ScrollData::new(),

--- a/src/ui/split_screen.rs
+++ b/src/ui/split_screen.rs
@@ -1,4 +1,6 @@
 use super::history::History;
+use super::input_layout;
+use super::layout::{ScreenLayout, INPUT_HEIGHT_MIN};
 use super::scroll_data::ScrollData;
 use super::top_area::{
     self, row_names, TopArea, TopPrefix, TopPrefixStyle, TopRenderContext, TopRowBody,
@@ -146,6 +148,15 @@ pub struct SplitScreen {
     prompt_line: u16,
     status_area: StatusArea,
     cursor_prompt_pos: u16,
+    /// Cursor row *within* the input area, counted from `prompt_line`. Always
+    /// zero while the input area is one row tall.
+    cursor_prompt_row: u16,
+    /// Rows granted to the user input area. Pinned at [`INPUT_HEIGHT_MIN`]
+    /// until the height plumbing lands; the multi-row render path below is
+    /// therefore compiled but not yet reachable.
+    input_height: u16,
+    /// Whether the input area grows past `input_height` as content requires.
+    input_auto_expand: bool,
     history: History,
     scroll_data: ScrollData,
     connection: Option<String>,
@@ -181,9 +192,6 @@ impl UserInterface for SplitScreen {
         if width > 0 && height > 0 {
             self.width = width;
             self.height = height;
-            self.output_line = height - self.status_area.height() - 2;
-            self.mud_prompt_line = height - self.status_area.height() - 1;
-            self.prompt_line = height;
 
             // Reconcile built-in top row config with current settings.
             // Each visible row consumes one screen line above the output
@@ -218,7 +226,29 @@ impl UserInterface for SplitScreen {
                     row.visible = !hide_topbar;
                 }
             }
-            self.output_start_line = self.top_area.visible_row_count() + 1;
+            // The top area's height is only known once the rows above have
+            // been reconciled, and it is an input to every other boundary.
+            let layout = ScreenLayout::compute(
+                height,
+                self.top_area.visible_row_count(),
+                self.status_area.height(),
+                INPUT_HEIGHT_MIN,
+            )
+            .ok_or(TerminalSizeError)?;
+
+            self.output_start_line = layout.output_start_line;
+            self.output_line = layout.output_line;
+            self.mud_prompt_line = layout.mud_prompt_line;
+            self.prompt_line = layout.input_start_line;
+
+            // The layout may have taken rows away from the status area to keep
+            // the output region renderable.
+            if layout.status_height != self.status_area.height() {
+                self.status_area
+                    .set_height(layout.status_height, self.mud_prompt_line + 1);
+            } else {
+                self.status_area.update_pos(self.mud_prompt_line + 1);
+            }
 
             write!(
                 self.screen,
@@ -297,8 +327,30 @@ impl UserInterface for SplitScreen {
         self.prompt_input = input.to_string();
         self.prompt_input_pos = pos;
 
-        // Calculate display width up to cursor position
-        let (byte_idx_at_cursor, _) = input.byte_index_at_display_width(pos);
+        if self.input_height > INPUT_HEIGHT_MIN {
+            self.print_prompt_input_rows(input, pos);
+            return;
+        }
+
+        // Single-row rendering is kept exactly as it was, horizontal `>`
+        // scrolling included, rather than being folded into the row path. The
+        // two solve different problems — one scrolls a viewport sideways, the
+        // other wraps — and this is the path every user is on today.
+        self.cursor_prompt_row = 0;
+
+        // Calculate display width up to cursor position.
+        //
+        // `pos` is a character index, so it is converted by counting
+        // characters. It used to be handed to `byte_index_at_display_width`,
+        // which reads its argument as a column count — the two agree only
+        // while every character is one column wide, so a CJK glyph anywhere
+        // left of the cursor dragged the cursor backwards by one column per
+        // glyph.
+        let byte_idx_at_cursor = input
+            .char_indices()
+            .nth(pos)
+            .map(|(idx, _)| idx)
+            .unwrap_or(input.len());
         let mut cursor_display_pos = (&input[..byte_idx_at_cursor]).display_width();
 
         let mut input = input;
@@ -332,10 +384,14 @@ impl UserInterface for SplitScreen {
         self.cursor_prompt_pos = cursor_display_pos as u16 + cursor_offset;
 
         let wrap_indicator = if wrapped { ">" } else { "" };
+        // The `cursor::Save`/`Restore` pair that used to bracket this write is
+        // gone. DECSC provides one save slot per screen buffer, so saving here
+        // destroyed the position `setup()` deliberately stored — and the
+        // restore was unobservable anyway, because `goto_prompt()` overwrites
+        // the cursor position on the very next byte.
         write!(
             self.screen,
-            "{}{}{}{}{}{}{}{}{}{}",
-            termion::cursor::Save,
+            "{}{}{}{}{}{}{}{}",
             termion::cursor::Goto(1, self.prompt_line),
             Fg(termion::color::Reset),
             Bg(termion::color::Reset),
@@ -343,7 +399,6 @@ impl UserInterface for SplitScreen {
             termion::clear::CurrentLine,
             wrap_indicator,
             input,
-            termion::cursor::Restore,
             self.goto_prompt(),
         )
         .unwrap();
@@ -712,25 +767,31 @@ impl SplitScreen {
     pub fn new(screen: Box<dyn Write>, history: History) -> Result<Self> {
         let (width, height) = termion::terminal_size()?;
 
-        let output_start_line = 2;
+        // `setup()` recomputes this from the live top-area row count before
+        // anything is drawn; the initial guess only has to be self-consistent.
+        // Deriving it here from the same function `setup()` uses is what keeps
+        // the two from drifting apart.
+        let top_rows = TopArea::new_default().visible_row_count();
         let status_area_height = 1;
-        let output_line = height - status_area_height - 2;
-        let mud_prompt_line = height - status_area_height - 1;
-        let prompt_line = height;
+        let layout = ScreenLayout::compute(height, top_rows, status_area_height, INPUT_HEIGHT_MIN)
+            .ok_or(TerminalSizeError)?;
 
-        let status_area = StatusArea::new(status_area_height, mud_prompt_line + 1, width);
+        let status_area = StatusArea::new(layout.status_height, layout.mud_prompt_line + 1, width);
 
         Ok(Self {
             screen,
             width,
             height,
-            output_start_line,
-            output_line,
-            mud_prompt_line,
+            output_start_line: layout.output_start_line,
+            output_line: layout.output_line,
+            mud_prompt_line: layout.mud_prompt_line,
             mud_prompt: Line::from(""),
             status_area,
-            prompt_line,
+            prompt_line: layout.input_start_line,
             cursor_prompt_pos: 1,
+            cursor_prompt_row: 0,
+            input_height: layout.input_height,
+            input_auto_expand: false,
             history,
             scroll_data: ScrollData::new(),
             connection: None,
@@ -775,6 +836,55 @@ impl SplitScreen {
             )
             .unwrap();
         }
+    }
+
+    /// The height the input area wants for `row_count` rows of content.
+    ///
+    /// With auto-expand off this is just the configured height, which is why
+    /// wiring it up now changes nothing.
+    fn effective_input_height(&self, row_count: usize) -> u16 {
+        input_layout::desired_height(row_count, self.input_height, self.input_auto_expand)
+    }
+
+    /// Paint the input area as wrapped rows. Used when the area is taller than
+    /// one row; `print_prompt_input` keeps the horizontal-scroll path for the
+    /// single-row case.
+    fn print_prompt_input_rows(&mut self, input: &str, pos: usize) {
+        let rows = input_layout::rows(input, self.width);
+        let (cursor_row, cursor_col) = input_layout::cursor_row_col(input, pos, self.width);
+        let height = self.effective_input_height(rows.len());
+        let window = input_layout::visible_rows(rows.len(), cursor_row as usize, height);
+
+        self.cursor_prompt_row = (cursor_row as usize).saturating_sub(window.start) as u16;
+        self.cursor_prompt_pos = cursor_col + 1;
+
+        let mut out = String::new();
+        // Erase by *region* extent, not content extent. Terminal cells persist
+        // until something overwrites them, so a clear loop bounded by the row
+        // count never visits the rows the input just gave up — backspacing
+        // past a wrap or submitting would leave the old text sitting below the
+        // live input.
+        for offset in 0..height {
+            let text = window
+                .start
+                .checked_add(offset as usize)
+                .filter(|i| *i < window.end)
+                .map(|i| &input[rows[i].clone()])
+                .unwrap_or("");
+
+            out.push_str(&format!(
+                "{}{}{}{}{}{}",
+                termion::cursor::Goto(1, self.prompt_line + offset),
+                Fg(termion::color::Reset),
+                Bg(termion::color::Reset),
+                termion::style::Reset,
+                termion::clear::CurrentLine,
+                text,
+            ));
+        }
+        out.push_str(&self.goto_prompt());
+
+        write!(self.screen, "{out}").unwrap();
     }
 
     fn clear_prompt(&mut self) {
@@ -832,7 +942,10 @@ impl SplitScreen {
     fn goto_prompt(&self) -> String {
         format!(
             "{}",
-            termion::cursor::Goto(self.cursor_prompt_pos, self.prompt_line),
+            termion::cursor::Goto(
+                self.cursor_prompt_pos,
+                self.prompt_line + self.cursor_prompt_row
+            ),
         )
     }
 
@@ -841,17 +954,25 @@ impl SplitScreen {
         if self.scroll_range() < self.output_range() {
             self.scroll_data.split = true;
             let scroll_range = self.scroll_range();
+
+            // The divider sits directly below the frozen scrollback rows; the
+            // live region starts on the row after it. Spelling that as a
+            // literal `3` was only correct while `output_start_line` was
+            // pinned at 2 — it moves as soon as a top row is hidden or the tab
+            // indicator appears, putting the divider *inside* the scroll
+            // region, where the next MUD line scrolls it away.
+            let divider_line = scroll_range + self.output_start_line;
             write!(self.screen, "{ResetScrollRegion}")?;
             write!(
                 self.screen,
                 "{}{}",
-                ScrollRegion(scroll_range + 3, self.output_line),
+                ScrollRegion(divider_line + 1, self.output_line),
                 DisableOriginMode
             )?;
             write!(
                 self.screen,
                 "{}{}{:━<4$}{}",
-                cursor::Goto(1, scroll_range + self.output_start_line),
+                cursor::Goto(1, divider_line),
                 color::Fg(color::Green),
                 "━ (scroll) ",
                 color::Fg(color::Reset),
@@ -902,9 +1023,18 @@ impl SplitScreen {
         Ok(())
     }
 
+    /// Rows of frozen scrollback shown while scrolling.
+    ///
+    /// The split reserves `SCROLL_LIVE_BUFFER_SIZE` rows at the bottom of the
+    /// output region for live output, so it is only possible when the output
+    /// region has more rows than that. The old guard tested the *terminal*
+    /// height instead, which says nothing about how many rows the output
+    /// region was actually left with once the top, status and input areas took
+    /// their share — so the subtraction below wrapped to ~65530 and was handed
+    /// straight to DECSTBM.
     fn scroll_range(&self) -> u16 {
-        if self.scroll_data.allow_split && self.height > SCROLL_LIVE_BUFFER_SIZE * 2 {
-            self.output_line - self.output_start_line - SCROLL_LIVE_BUFFER_SIZE + 1
+        if self.scroll_data.allow_split && self.output_range() > SCROLL_LIVE_BUFFER_SIZE {
+            self.output_range() - SCROLL_LIVE_BUFFER_SIZE
         } else {
             self.output_range()
         }
@@ -918,6 +1048,7 @@ impl SplitScreen {
 #[cfg(test)]
 mod screen_test {
     use super::*;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn test_append_history() {
@@ -1095,5 +1226,174 @@ mod screen_test {
             .collect::<String>();
 
         assert_eq!(clean_output, "━ this t ━");
+    }
+
+    // ---- Input area rendering -------------------------------------------
+    //
+    // `SplitScreen::new` needs a real terminal, so these build the struct
+    // directly against a capturing writer. That is the only way to get the
+    // render path itself under test rather than testing a reimplementation of
+    // it beside the code that ships.
+
+    #[derive(Clone)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A screen `width` columns wide with an `input_height`-row input area
+    /// starting at row `prompt_line`, plus the buffer it renders into.
+    fn test_screen(width: u16, input_height: u16) -> (SplitScreen, Arc<Mutex<Vec<u8>>>) {
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let height = 24;
+        let layout = ScreenLayout::compute(height, 2, 1, input_height).unwrap();
+        let screen = SplitScreen {
+            screen: Box::new(SharedBuf(sink.clone())),
+            width,
+            height,
+            output_start_line: layout.output_start_line,
+            output_line: layout.output_line,
+            mud_prompt_line: layout.mud_prompt_line,
+            mud_prompt: Line::from(""),
+            status_area: StatusArea::new(layout.status_height, layout.mud_prompt_line + 1, width),
+            prompt_line: layout.input_start_line,
+            cursor_prompt_pos: 1,
+            cursor_prompt_row: 0,
+            input_height: layout.input_height,
+            input_auto_expand: false,
+            history: History::new(),
+            scroll_data: ScrollData::new(),
+            connection: None,
+            tags: HashSet::new(),
+            prompt_input: String::new(),
+            prompt_input_pos: 0,
+            show_tags: false,
+            tag_mask: TagMask::default(),
+            top_area: TopArea::new_default(),
+            tabs_metadata: Vec::new(),
+            inline_tabs_setting: false,
+        };
+        (screen, sink)
+    }
+
+    fn rendered(sink: &Arc<Mutex<Vec<u8>>>) -> String {
+        String::from_utf8(sink.lock().unwrap().clone()).unwrap()
+    }
+
+    /// The default configuration must not take the row path at all — this is
+    /// the guard that the refactor left every existing user where they were.
+    #[test]
+    fn single_row_input_keeps_the_horizontal_scroll_path() {
+        let (mut screen, sink) = test_screen(20, 1);
+        assert_eq!(screen.input_height, INPUT_HEIGHT_MIN);
+
+        // Longer than the width, with the cursor at the end: the single-row
+        // path scrolls sideways behind a '>' rather than wrapping.
+        let input = "abcdefghijklmnopqrstuvwxyz";
+        screen.print_prompt_input(input, input.chars().count());
+
+        let out = rendered(&sink);
+        assert!(
+            out.contains('>'),
+            "expected the scroll indicator in {out:?}"
+        );
+        assert_eq!(screen.cursor_prompt_row, 0);
+        // Everything lands on the one input row.
+        assert_eq!(
+            out.matches(&format!("{}", termion::cursor::Goto(1, screen.prompt_line)))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn multi_row_input_wraps_instead_of_scrolling() {
+        let (mut screen, sink) = test_screen(10, 3);
+        let input = "abcdefghijklmno"; // 15 chars over 10 columns -> 2 rows
+        screen.print_prompt_input(input, input.chars().count());
+
+        let out = rendered(&sink);
+        assert!(!out.contains('>'), "row path must not scroll sideways");
+        assert!(out.contains("abcdefghij"));
+        assert!(out.contains("klmno"));
+        assert_eq!(screen.cursor_prompt_row, 1);
+        assert_eq!(screen.cursor_prompt_pos, 6); // 5 columns in, 1-based
+    }
+
+    /// Newlines start new rows rather than being emitted as raw control
+    /// characters.
+    #[test]
+    fn multi_row_input_renders_logical_rows() {
+        let (mut screen, sink) = test_screen(20, 3);
+        screen.print_prompt_input("one\ntwo", 7);
+
+        let out = rendered(&sink);
+        assert!(out.contains("one"));
+        assert!(out.contains("two"));
+        assert_eq!(screen.cursor_prompt_row, 1);
+        assert_eq!(screen.cursor_prompt_pos, 4);
+    }
+
+    /// The input area is erased by region extent. A content-bounded clear
+    /// leaves the rows the input just gave up still showing their old text.
+    #[test]
+    fn every_input_row_is_erased_even_when_content_shrinks() {
+        let (mut screen, sink) = test_screen(20, 3);
+
+        // Three rows of content, then one.
+        screen.print_prompt_input("a\nb\nc", 5);
+        sink.lock().unwrap().clear();
+        screen.print_prompt_input("a", 1);
+
+        let out = rendered(&sink);
+        for offset in 0..3 {
+            let goto = format!("{}", termion::cursor::Goto(1, screen.prompt_line + offset));
+            assert!(
+                out.contains(&goto),
+                "row {offset} was never visited, so its old content survives"
+            );
+        }
+        assert_eq!(
+            out.matches(&format!("{}", termion::clear::CurrentLine))
+                .count(),
+            3,
+            "each of the three rows must be cleared"
+        );
+    }
+
+    /// Content taller than the area scrolls within it, and the cursor stays
+    /// inside the visible window.
+    #[test]
+    fn content_taller_than_the_area_scrolls_within_it() {
+        let (mut screen, sink) = test_screen(20, 2);
+        let input = "r0\nr1\nr2\nr3";
+        screen.print_prompt_input(input, input.chars().count());
+
+        let out = rendered(&sink);
+        assert!(out.contains("r2") && out.contains("r3"));
+        assert!(!out.contains("r0"), "row 0 has scrolled out of the area");
+        assert!(screen.cursor_prompt_row < screen.input_height);
+    }
+
+    /// `goto_prompt` addresses the cursor's row within the area, not always
+    /// the first row — every other draw path appends it, so a wrong row here
+    /// would misplace the cursor after any redraw.
+    #[test]
+    fn goto_prompt_targets_the_cursor_row() {
+        let (mut screen, _sink) = test_screen(20, 3);
+        screen.print_prompt_input("a\nb\nc", 5);
+
+        assert_eq!(screen.cursor_prompt_row, 2);
+        assert_eq!(
+            screen.goto_prompt(),
+            format!("{}", termion::cursor::Goto(2, screen.prompt_line + 2))
+        );
     }
 }

--- a/src/ui/ui_wrapper.rs
+++ b/src/ui/ui_wrapper.rs
@@ -106,7 +106,10 @@ impl UserInterface for UiWrapper {
 
     fn print_send(&mut self, send: &crate::model::Line) {
         if let Some(line) = send.print_line() {
-            self.tts_ctrl.lock().unwrap().speak_input(line);
+            self.tts_ctrl
+                .lock()
+                .unwrap()
+                .speak_input(line, send.flags.tts_interrupt);
         }
         self.screen.print_send(send);
     }
@@ -169,6 +172,14 @@ impl UserInterface for UiWrapper {
 
     fn set_status_area_height(&mut self, height: u16) -> Result<()> {
         self.screen.set_status_area_height(height)
+    }
+
+    fn set_input_height(&mut self, height: u16) -> Result<()> {
+        self.screen.set_input_height(height)
+    }
+
+    fn input_height(&self) -> u16 {
+        self.screen.input_height()
     }
 
     fn set_show_tags(&mut self, show: bool) -> Result<()> {

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -141,6 +141,67 @@ pub fn wrap_line(line: &str, width: usize, padding: usize) -> Vec<&str> {
     lines
 }
 
+/// Hard-wrap a single line to `width` display columns, **losslessly**.
+///
+/// This is deliberately a second wrapper rather than an option on
+/// [`wrap_line`]. `wrap_line` is tuned for MUD *output* and is lossy by
+/// design: it breaks on word boundaries and drops the boundary space, and it
+/// discards a trailing segment that is entirely whitespace. That is right for
+/// prose and wrong for an input area, where the wrapped rows have to partition
+/// the buffer exactly — a dropped space shifts every character after it, so
+/// the cursor would render a column away from the text it edits.
+///
+/// The returned slices concatenate back to `line` byte for byte. Breaks only
+/// ever land on printable-character boundaries, so an escape sequence is never
+/// split; escapes are carried into whatever row they start in and consume no
+/// columns. A consequence, accepted rather than fixed: an SGR run that spans a
+/// break is not re-emitted on the continuation row, so styling stops there.
+///
+/// `line` must not contain `'\n'`. The vte parser behind
+/// `printable_char_indices` routes `'\n'` to `execute`, not `print`, so it is
+/// invisible here and two logical rows would silently be measured as one.
+/// Split on `'\n'` first, then call this on each segment.
+pub fn wrap_line_hard(line: &str, width: usize) -> Vec<&str> {
+    debug_assert!(
+        !line.contains('\n'),
+        "wrap_line_hard cannot see '\\n'; split on it first"
+    );
+
+    // A zero width would make every row empty and the loop never advance.
+    let width = width.max(1);
+    let mut rows: Vec<&str> = vec![];
+    let mut start = 0;
+
+    while start < line.len() {
+        let rest = &line[start..];
+        let (mut cut, _) = rest.byte_index_at_display_width(width);
+
+        if cut == 0 {
+            // The next glyph is wider than the whole row — a double-width
+            // character at `width == 1`, say. Nothing fits, but the row must
+            // still consume something or this loop spins forever. Overflow the
+            // row by one character, which is also what a terminal does.
+            cut = match rest.printable_char_indices().next() {
+                Some((idx, c)) => idx + c.len_utf8(),
+                // No printable characters at all (a bare escape sequence);
+                // take the remainder so the bytes are not lost.
+                None => rest.len(),
+            };
+        }
+
+        rows.push(&rest[..cut]);
+        start += cut;
+    }
+
+    // An empty input is one empty row, not zero rows — there is still a row
+    // the cursor sits on.
+    if rows.is_empty() {
+        rows.push(line);
+    }
+
+    rows
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -242,5 +303,91 @@ mod tests {
         // "abcdefghij" = 10 printable chars; at width 5 it must wrap.
         let lines = wrap_line(line, 5, 0);
         assert_eq!(lines.len(), 2);
+    }
+
+    /// The reason a second wrapper exists at all: `wrap_line` is lossy, and an
+    /// input area cannot be. Both properties are asserted side by side so the
+    /// justification cannot quietly stop being true.
+    #[test]
+    fn wrap_line_hard_preserves_all_characters() {
+        for line in [
+            "the quick brown fox jumps over the lazy dog",
+            "a b c d e f g h i j k l m n o p",
+            "trailing space kept   ",
+            "   leading space kept",
+            "no-spaces-at-all-in-this-very-long-token-here",
+            "",
+            " ",
+        ] {
+            for width in 1..=20usize {
+                let rows = wrap_line_hard(line, width);
+                assert_eq!(rows.concat(), line, "lossy at width {width} for {line:?}");
+            }
+        }
+
+        // And the contrast: where `wrap_line` takes its word-break path it
+        // drops the boundary space, so it fails the same round-trip. That is
+        // correct for MUD output, and is why it is left alone.
+        let line = "aaa bbb ccc";
+        assert_eq!(wrap_line(line, 6, 0), vec!["aaa", "bbb", "ccc"]);
+        assert_eq!(wrap_line(line, 6, 0).concat(), "aaabbbccc");
+        assert_eq!(wrap_line_hard(line, 6).concat(), line);
+    }
+
+    /// Every row must fit the terminal, except when a single glyph cannot.
+    #[test]
+    fn wrap_line_hard_rows_fit_the_width() {
+        let line = "hello 中文 world";
+        for width in 2..=20usize {
+            for row in wrap_line_hard(line, width) {
+                assert!(
+                    row.display_width() <= width,
+                    "row {row:?} exceeds width {width}"
+                );
+            }
+        }
+    }
+
+    /// A double-width glyph in a one-column terminal fits nowhere. The row has
+    /// to overflow rather than the wrap loop spinning forever.
+    #[test]
+    fn wrap_line_hard_terminates_on_glyph_wider_than_terminal() {
+        let rows = wrap_line_hard("中文", 1);
+        assert_eq!(rows, vec!["中", "文"]);
+        assert_eq!(rows.concat(), "中文");
+    }
+
+    /// Breaks land on printable-character boundaries, so an escape sequence is
+    /// never cut in half — a split escape would be printed as literal garbage.
+    #[test]
+    fn wrap_line_hard_never_splits_an_escape_sequence() {
+        let line = "\x1b[31mred\x1b[0m and \x1b[32mgreen\x1b[0m";
+        for width in 1..=20usize {
+            let rows = wrap_line_hard(line, width);
+            assert_eq!(rows.concat(), line);
+            for row in rows {
+                // A row holding a partial CSI would have an unterminated
+                // `\x1b[` with no final byte.
+                if let Some(esc) = row.rfind('\x1b') {
+                    assert!(
+                        row[esc..].chars().any(|c| c.is_ascii_alphabetic()),
+                        "row {row:?} ends mid-escape"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Escapes consume no columns, so they must not push text onto a new row.
+    #[test]
+    fn wrap_line_hard_escapes_do_not_consume_columns() {
+        let rows = wrap_line_hard("\x1b[31mabcde\x1b[0m", 5);
+        assert_eq!(rows.len(), 1);
+    }
+
+    /// Empty input is one row, not zero — the cursor still sits somewhere.
+    #[test]
+    fn wrap_line_hard_empty_input_is_one_row() {
+        assert_eq!(wrap_line_hard("", 10), vec![""]);
     }
 }

--- a/src/ui/user_interface.rs
+++ b/src/ui/user_interface.rs
@@ -59,6 +59,15 @@ pub trait UserInterface {
     fn remove_tag(&mut self, proto: &str) -> Result<()>;
     fn clear_tags(&mut self) -> Result<()>;
     fn set_status_area_height(&mut self, height: u16) -> Result<()>;
+    fn set_input_height(&mut self, height: u16) -> Result<()>;
+    /// The number of rows the input area *actually* occupies.
+    ///
+    /// Deliberately a report rather than an echo of what Lua requested.
+    /// The two diverge on a terminal too short to honour the request, and
+    /// in reader mode, where the setter is a no-op — and NAWS reports this
+    /// to the MUD, so an echo would corrupt server-side wrapping for
+    /// precisely the users who hear the artifacts read aloud.
+    fn input_height(&self) -> u16;
     fn set_show_tags(&mut self, show: bool) -> Result<()>;
     fn set_tag_mask(&mut self, mask: TagMask);
     fn set_history_capacity(&mut self, capacity: usize);

--- a/tests/input_area_tests.lua
+++ b/tests/input_area_tests.lua
@@ -1,0 +1,67 @@
+require "tests.common"
+
+-- Exercises the multi-line input area's Lua surface end to end in headless
+-- mode. Headless screens report an input height of 1 regardless of what is
+-- requested, so the assertions here cover the API contract — clamping,
+-- get-returns-set, row arithmetic — rather than rendering, which is not
+-- reachable without a terminal.
+
+script.on_reset(function()
+    blight.quit()
+end)
+
+-- ---- blight.input_height ------------------------------------------------
+assert_eq(blight.input_height(), 1)   -- default leaves today's layout alone
+
+assert_eq(blight.input_height(3), 3)  -- set returns what was set
+assert_eq(blight.input_height(), 3)   -- and reads back
+
+assert_eq(blight.input_height(0), 1)     -- zero would leave nowhere to type
+assert_eq(blight.input_height(500), 10)  -- bounded so output stays renderable
+
+-- Ask for five rows. A headless screen cannot give them, and the deferred
+-- check below asserts that what reads back is what the screen granted.
+blight.input_height(5)
+
+-- ---- prompt row arithmetic ----------------------------------------------
+prompt.set("")
+assert_eq(prompt.row_count(), 1)
+assert_eq(prompt.cursor_row(), 1)
+
+-- Row breaks round-trip through prompt.set/get rather than being emitted as
+-- raw control characters, which is what used to happen.
+prompt.set("one\ntwo\nthree")
+assert_eq(prompt.get(), "one\ntwo\nthree")
+assert_eq(prompt.row_count(), 3)
+
+-- A buffer with no row breaks is one row, which is what makes the up/down
+-- bindings fall through to command history exactly as before.
+prompt.set("no rows here")
+assert_eq(prompt.row_count(), 1)
+assert_eq(prompt.cursor_row(), 1)
+
+-- ---- the input_auto_expand setting exists and defaults off ---------------
+assert_eq(settings.get("input_auto_expand"), false)
+settings.set("input_auto_expand", true)
+assert_eq(settings.get("input_auto_expand"), true)
+settings.set("input_auto_expand", false)
+
+-- ---- set_newline_keys ---------------------------------------------------
+-- Retargeting the whole group must not error, including the empty case that
+-- disables row insertion entirely. This is what catches the bind/unbind
+-- normalisation asymmetry: unbind does no case folding, so the helper has to
+-- unbind exactly the strings bind stored.
+set_newline_keys({ "alt-enter" })
+set_newline_keys({ "ctrl-o", "\x1b[13;2u" })
+set_newline_keys({})
+set_newline_keys({ "ctrl-o", "alt-enter", "\x1b\r", "\x1b\n" })
+
+-- ---- Deferred: let the queued events drain, then finish ------------------
+timer.add(1, 1, function()
+    -- Five rows were requested above, but a headless screen has one. This is
+    -- why input_height() is a report of what the screen granted rather than an
+    -- echo of the request: NAWS sends this number to the MUD, so an echo would
+    -- advertise a window height the screen never had.
+    assert_eq(blight.input_height(), 1)
+    script.reset()
+end)

--- a/tests/lua_tests.rs
+++ b/tests/lua_tests.rs
@@ -28,6 +28,11 @@ fn test_tabs() {
 }
 
 #[test]
+fn test_input_area() {
+    test_script("tests/input_area_tests.lua");
+}
+
+#[test]
 fn test_exec() {
     test_script("tests/exec_tests.lua");
 }


### PR DESCRIPTION
Closes #1472 — an input area more than one row tall, so longer messages can be composed and read back before being sent.

> **Depends on #1479 — that one must merge first.**
> This branch is #1479's branch plus one commit, so **the diff below currently includes #1479's changes too.** A cross-fork PR has to target `dev`, so there's no way to scope the diff to just this commit until #1479 lands.
>
> Review `Add a multi-line input area` (the second commit) as this PR; the first commit is #1479 and is reviewed there.
>
> Once #1479 merges I'll rebase onto the squashed commit and the diff here will shrink to the feature alone. Merging this before #1479 would pull in both at once.

Since #1472 is labelled `discussion` and not yet accepted, I've posted the design on the issue and would welcome a steer before this gets a close review — several decisions here are policy rather than mechanism.

## Usage

```lua
blight.input_height(3)      -- a fixed three-row input area
```
```
/set input_auto_expand on   -- or let it grow and shrink with the content
```

Defaults are unchanged: one row, auto-expand off, single-row rendering path untouched.

## Design decisions

**Enter always submits; `Ctrl-O` inserts a row.** `Alt-Enter` and the raw `\x1b\r` / `\x1b\n` forms are bound too, and `set_newline_keys{...}` retargets the whole group in one call.

`Ctrl-O` is primary rather than `Alt-Enter` because Alt+Enter doesn't work on a stock Mac — Terminal.app and iTerm2 both ship with Option producing accented characters rather than a Meta prefix. `Ctrl-J` isn't usable at all, being byte-identical to Enter. This also affects the existing `alt-b`/`alt-f`/`alt-d` defaults on stock macOS; documented, not fixed here.

Binding `alt-enter` needed a fix first: `Key::Alt('\r')` minted the binding name `"alt-\n"` — a literal newline — so `blight.bind("alt-enter", ...)` silently never fired.

**Submit fans out into one `ServerInput` per row.** A `Line` with an embedded `\n` would be telnet-sent raw and match no alias. An empty buffer still emits exactly one blank line, since pagers depend on a bare Enter arriving — there's a regression test pinning that.

**Up/Down move within the input area, falling through to history at the edges.** The decision stays in Lua where history already lives, using new `prompt.cursor_row()` / `prompt.row_count()`; `blight.ui` actions are applied *after* a binding returns, so a binding can't otherwise observe whether a motion moved. `ctrl-p`/`ctrl-n` stay bound to history unconditionally.

Rows for motion are newline-delimited, not visual. Visual motion would need the terminal width, which the input thread can't reach, and would break history navigation for reader-mode users specifically since `ReaderScreen` never wraps. Documented cost: on a single soft-wrapped long line, up/down go to history rather than moving visually.

**`blight.input_height()` reports what the screen granted, not what was requested.** Those differ on a terminal too short to honour it, and in reader mode where the setter is a no-op. NAWS sends this number to the MUD, so an echo would advertise a window height the screen never had. The end-to-end test asks for 5 rows and asserts it reads back 1 from a headless screen.

## Accessibility

Reader mode stays one row and renders row breaks as a space. See the issue thread — I've asked there for input from screen-reader users, since `tdsr` can handle multi-row regions and this may be the convenient call rather than the right one.

Two bugs fixed regardless:

- **`'\n'` was silently dropped in reader mode.** vte routes it to `execute`, not `print`, so `printable_chars` never sees it — two rows would have read out as `"onetwo"`. The substitution happens *before* the existing sanitize. The substitute is one character of one display column because `pos` indexes the pre-substitution buffer and the column computed there is `tdsr`'s reading anchor: a one-column drift is a mis-announcement, not a cosmetic glitch.
- **A multi-row submit would have announced only its last row.** `speak_input` opens with `flush()` = `queue.flush(); tts.stop()`, so rows sent in a tight loop enqueue and immediately cancel each other. Only the first row of a batch interrupts now. Without this the feature's benefit inverts into a correctness hazard for exactly the users it's meant to help.

`ReaderScreen` had no automated coverage at all; it now has some, via a capturing writer rather than a TTY.

## NAWS

`naws.lua` subtracted a hardcoded `2`. That's *decomposed* rather than replaced wholesale — the mud-prompt row still exists, so it's `height - 1 - blight.input_height() - blight.status_height()`. Replacing the whole `2` with `input_height()` would have reported the window one row too tall at the default, a new regression inside a fix.

Separately, the dimension-change listeners that drive NAWS only fired on `Redraw`, so resizing a region never re-reported the writable area. Pre-existing for `status_height`; fixed here for both.

## Rendering

Auto-expand deliberately does **not** route through `setup()`. `setup()` opens with `clear::All` + `ResetScrollRegion`, reloads settings from disk, and repaints with a `flush()` in between — a blank-then-content two-frame sequence. That's fine on a resize and not fine on the keystroke that happens to wrap onto a new row, which is when auto-expand fires. It gets a separate path that re-emits only the scroll region.

The input area is erased by *region* extent, not content extent: terminal cells persist, so a clear loop bounded by the row count never visits the rows the input just gave up, leaving ghost text below the live input.

## Also fixed

- `prompt_input.len()` used as a character index in the `Redraw` path (it's a byte length).
- A configured input height was silently lost across the screen swap a reader-mode toggle performs.

## Testing

507 unit tests and 8 end-to-end Lua tests pass (`cargo test --locked`) — 12 unit tests and 1 Lua suite more than #1479. `cargo fmt --check` and `stylua --check` on the changed Lua files are clean, and `cargo clippy --locked` produces a warning set identical to `dev` — no new warnings.

New regression tests were checked by mutation — e.g. removing the reader-mode newline substitution fails both reader tests.

**Not yet verified on real terminals.** The macOS key matrix in particular (stock Terminal.app and iTerm2 with Option-as-Meta *off*, then on, then both inside tmux) needs a human at a keyboard. I'll do that before asking for merge.

