### PR TITLE
Use core.time()/1000 instead of os.time()

### DIFF
--- a/resources/lua/alias.lua
+++ b/resources/lua/alias.lua
@@ -56,9 +56,9 @@ function Alias:check_line(line)
     local matches = self.regex:match(str)
     if matches then
         line:matched(true)
-        local startTime = os.time()
+        local startTime = core.time() / 1000
         debug.sethook(function()
-            if os.time() > startTime + 2 then
+            if core.time() / 1000 > startTime + 2 then
                 debug.sethook()
                 error("Alias callback has been running for +2 seconds. Aborting", 2)
             end

--- a/resources/lua/tasks.lua
+++ b/resources/lua/tasks.lua
@@ -61,7 +61,7 @@ function Task:startLater(time)
     if self.dead then
         error("Attempt to start dead task")
     end
-    pendingTasks[self] = { time = os.time() + time }
+    pendingTasks[self] = { time = (core.time() / 1000) + time }
 end
 
 function Task:kill()
@@ -81,8 +81,8 @@ function Task:sleep(time)
         return
     end
 
-    if data.time < os.time() then
-        data.time = os.time() + time
+    if data.time < core.time() / 1000 then
+        data.time = core.time() / 1000 + time
     else
         data.time = data.time + time
     end
@@ -141,9 +141,9 @@ end
 
 local function run_task(task)
     currentTask = task
-    local startTime = os.time()
+    local startTime = core.time() / 1000
     debug.sethook(task.coro, function()
-        if os.time() > startTime + 2 then
+        if core.time() / 1000 > startTime + 2 then
             debug.sethook()
             error("Task has been running for +2 seconds without yielding. Aborting", 2)
         end
@@ -177,7 +177,7 @@ timer.on_tick(function(millis)
     local somethingRan = false
 
     for task, timespec in pairs(tasks) do
-        if timespec.time < os.time() and not timespec.idle then
+        if timespec.time < core.time() / 1000 and not timespec.idle then
             somethingRan = true
             run_task(task)
         end

--- a/resources/lua/trigger.lua
+++ b/resources/lua/trigger.lua
@@ -79,9 +79,9 @@ function Trigger:check_line(line)
             self.count = self.count - 1
         end
 
-        local startTime = os.time()
+        local startTime = core.time() / 1000
         debug.sethook(function()
-            if os.time() > startTime + 2 then
+            if core.time() / 1000 > startTime + 2 then
                 debug.sethook()
                 error("Trigger callback has been running for +2 seconds. Aborting", 2)
             end

--- a/tests/task_tests.lua
+++ b/tests/task_tests.lua
@@ -3,6 +3,8 @@ require("tests.common")
 script.on_reset(function()
     blight.quit()
 end)
+local sleep_period = 0.4 -- we want this to be multiple ticks
+local result_wait = sleep_period + 0.25 -- 1 tick to start sleep_task + sleep_period + 1 tick to resume + a bit more so we are in the next tick
 
 assert(tasks.is_task(tasks.Task.new(function() end)), "Task.new object should be a task")
 assert(not tasks.is_task({}), "Plain table should not be a task")
@@ -26,7 +28,7 @@ assert_eq(unstarted_task.args[2], 20)
 assert_eq(tasks.get_current(), nil)
 assert_eq(tasks.Task.get_current(), nil)
 
-local sleep_ok, sleep_err = pcall(function() tasks.sleep(1) end)
+local sleep_ok, sleep_err = pcall(function() tasks.sleep(sleep_period) end)
 assert(not sleep_ok, "tasks.sleep in main task should fail")
 assert(string.find(sleep_err, "Cannot sleep main task"), "Error should mention 'Cannot sleep main task'")
 
@@ -42,7 +44,7 @@ local start_dead_ok, start_dead_err = pcall(function() dead_task:start() end)
 assert(not start_dead_ok, "Starting dead task should fail")
 assert(string.find(start_dead_err, "Attempt to start dead task"), "Error should mention dead task")
 
-local start_later_dead_ok, start_later_dead_err = pcall(function() dead_task:startLater(1) end)
+local start_later_dead_ok, start_later_dead_err = pcall(function() dead_task:startLater(sleep_period) end)
 assert(not start_later_dead_ok, "StartLater on dead task should fail")
 assert(string.find(start_later_dead_err, "Attempt to start dead task"), "Error should mention dead task")
 
@@ -116,12 +118,12 @@ end)
 
 local sleep_task = tasks.spawn(function()
     mud.output("sleep_task started")
-    tasks.sleep(1)
+    tasks.sleep(sleep_period)
     mud.output("sleep_task resumed")
     test_results.sleep_task_resumed = true
 end)
 
-local spawn_later_task = tasks.spawn_later(1, function()
+local spawn_later_task = tasks.spawn_later(sleep_period, function()
     mud.output("spawn_later_task started")
     test_results.spawn_later_ran = true
 end)
@@ -134,14 +136,14 @@ end)
 
 local killed_task = tasks.spawn(function()
     mud.output("killed_task started")
-    tasks.sleep(1)
+    tasks.sleep(sleep_period)
     mud.output("killed_task resumed")
     test_results.killed_task_resumed = true
 end)
 
 killed_task:kill()
 assert_eq(killed_task.error, nil)
-local sleep_killed_ok, sleep_killed_err = pcall(function() killed_task:sleep(1) end)
+local sleep_killed_ok, sleep_killed_err = pcall(function() killed_task:sleep(sleep_period) end)
 assert(sleep_killed_ok, "Sleeping dead task should be ignored")
 assert_eq(sleep_killed_err, nil)
 
@@ -151,14 +153,14 @@ assert_eq(idle_killed_err, nil)
 
 mud.output(#tasks.get_tasks())
 
--- Timer at 0.5 seconds to check if slept/spawn_later tasks are still waiting
-timer.add(0.5, 1, function()
+-- Timer at 1 tick before sleep_period to check if slept/spawn_later tasks are still waiting
+timer.add(sleep_period - 0.1, 1, function()
     test_results.sleep_task_slept = not test_results.sleep_task_resumed
     test_results.spawn_later_waited = not test_results.spawn_later_ran
 end)
 
--- Wait for tasks to run and assert results
-timer.add(2.2, 1, function()
+-- Wait for tasks to run and assert results.
+timer.add(result_wait, 1, function()
     -- make sure task ran and killed itself first
     local sleep_self_killed_ok, sleep_self_killed_err = pcall(function() self_killed_task:sleep(0) end)
     assert(sleep_self_killed_ok, "Sleeping dead task should be ignored")

--- a/tests/task_tests.lua
+++ b/tests/task_tests.lua
@@ -3,8 +3,8 @@ require("tests.common")
 script.on_reset(function()
     blight.quit()
 end)
-local sleep_period = 0.4 -- we want this to be multiple ticks
-local result_wait = sleep_period + 0.25 -- 1 tick to start sleep_task + sleep_period + 1 tick to resume + a bit more so we are in the next tick
+local sleep_period = 0.5 -- we want this to be multiple ticks
+local result_wait = sleep_period + 0.3 -- 1 tick to start sleep_task + sleep_period + 1 tick to resume + a bit more so we are in the next tick
 
 assert(tasks.is_task(tasks.Task.new(function() end)), "Task.new object should be a task")
 assert(not tasks.is_task({}), "Plain table should not be a task")
@@ -153,8 +153,8 @@ assert_eq(idle_killed_err, nil)
 
 mud.output(#tasks.get_tasks())
 
--- Timer at 1 tick before sleep_period to check if slept/spawn_later tasks are still waiting
-timer.add(sleep_period - 0.1, 1, function()
+-- Timer at 2 ticks before sleep_period to check if slept/spawn_later tasks are still waiting
+timer.add(sleep_period - 0.2, 1, function()
     test_results.sleep_task_slept = not test_results.sleep_task_resumed
     test_results.spawn_later_waited = not test_results.spawn_later_ran
 end)


### PR DESCRIPTION
Standard Lua's `os.time` does not provide milliseconds, switch the builtin lua modules to use the already provided `core.time`. This should allow sub second sleeps with tasks like we can with timers.